### PR TITLE
Updating table API to be happier with non pg-idiomatic casing

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -50,7 +50,7 @@ Table.prototype.findOne = function(args, next){
 Table.prototype.count = function(){
   var args = ArgTypes.whereArgs(arguments);
 
-  var sql = "select COUNT(1) from " + this.fullname + " where " + args.where;
+  var sql = "select COUNT(1) from " + this.delimitedFullName + " where " + args.where;
   this.db.query(sql, args.params, {single : true}, function(err,res){
     if(err) args.next(err, null)
     else args.next(null, res.count)
@@ -62,7 +62,7 @@ Table.prototype.count = function(){
 Table.prototype.where = function(){
   var args = ArgTypes.whereArgs(arguments);
 
-  var sql = "select * from " + this.fullname + " where " + args.where;
+  var sql = "select * from " + this.delimitedFullName + " where " + args.where;
   this.db.query(sql, args.params, args.next);
 };
 

--- a/lib/table.js
+++ b/lib/table.js
@@ -114,7 +114,8 @@ Table.prototype.insert = function(data, next) {
   if(!data) throw "insert should be called with data";
   if (!_.isArray(data)) { data = [data]; }
 
-  var sql = util.format("INSERT INTO %s (%s) VALUES\n", this.delimitedFullName, _.map(_.keys(data[0]), function(key){return util.format('"%s"', key);}).join(", "));
+  var delimitedKeys = _.map(_.keys(data[0]), function(key){return util.format('"%s"', key);});
+  var sql = util.format("INSERT INTO %s (%s) VALUES\n", this.delimitedFullName, delimitedKeys.join(", "));
   var parameters = [];
   var values = []
   for(var i = 0, seed = 0; i < data.length; ++i) {

--- a/lib/table.js
+++ b/lib/table.js
@@ -194,7 +194,7 @@ Table.prototype.search = function(args, next){
   }else{
     tsv= util.format("concat(%s)", args.columns.join(", ' ',"));
   }
-  var sql = "select * from " + this.fullname + " where " + util.format("to_tsvector(%s)", tsv);
+  var sql = "select * from " + this.delimitedFullName + " where " + util.format('to_tsvector("%s")', tsv);
   sql+= " @@ to_tsquery($1);";
 
   this.db.query(sql, [args.term],next);

--- a/lib/table.js
+++ b/lib/table.js
@@ -114,7 +114,7 @@ Table.prototype.insert = function(data, next) {
   if(!data) throw "insert should be called with data";
   if (!_.isArray(data)) { data = [data]; }
 
-  var sql = util.format("INSERT INTO %s (%s) VALUES\n", this.fullname, _.keys(data[0]).join(", "));
+  var sql = util.format("INSERT INTO %s (%s) VALUES\n", this.delimitedFullName, _.map(_.keys(data[0]), function(key){return util.format('"%s"', key)}).join(", "));
   var parameters = [];
   var values = []
   for(var i = 0, seed = 0; i < data.length; ++i) {
@@ -139,18 +139,21 @@ Table.prototype.update = function(fields, where, next){
   });
   // var parsedWhere = parseWhere(where);
   var parsedWhere = Where.forTable(where);
-  var sql = util.format("UPDATE %s SET %s", this.fullname, f.join(', '));
+  var sql = util.format("UPDATE %s SET %s", this.delimitedFullName, f.join(', '));
   sql += parsedWhere.where;
   sql += " RETURNING *";
-
   this.db.query(sql, parameters, next)
 };
 
 Table.prototype.primaryKeyName = function(){
   return this.pk;
 };
+Table.prototype.delimitedPrimaryKeyName = function() {
+  return util.format('"%s"', this.pk);
+};
 Table.prototype.containsPk = function(args){
-  return _.keys(args).indexOf(this.primaryKeyName()) > -1;
+  var keys = _.keys(args);
+  return (keys.indexOf(this.primaryKeyName()) > -1) || (keys.indexOf(this.delimitedPrimaryKeyName()) > -1);
 };
 Table.prototype.save = function(args, next){
   assert(_.isObject(args), "Please pass in the criteria for saving as an object. This should include all fields needed to change or add. Include the primary key for an UPDATE.");
@@ -170,7 +173,7 @@ Table.prototype.save = function(args, next){
 
 Table.prototype.destroy = function(args, next){
   assert(_.isObject(args), "Please pass in the criteria for deleting. This should be in object format - {id : 1} for example");
-  var sql = "delete from " + this.fullname;
+  var sql = "delete from " + this.delimitedFullName;
   var where = Where.forTable(args);
   sql += where.where;
   sql += " RETURNING *";

--- a/lib/table.js
+++ b/lib/table.js
@@ -114,7 +114,7 @@ Table.prototype.insert = function(data, next) {
   if(!data) throw "insert should be called with data";
   if (!_.isArray(data)) { data = [data]; }
 
-  var sql = util.format("INSERT INTO %s (%s) VALUES\n", this.delimitedFullName, _.map(_.keys(data[0]), function(key){return util.format('"%s"', key)}).join(", "));
+  var sql = util.format("INSERT INTO %s (%s) VALUES\n", this.delimitedFullName, _.map(_.keys(data[0]), function(key){return util.format('"%s"', key);}).join(", "));
   var parameters = [];
   var values = []
   for(var i = 0, seed = 0; i < data.length; ++i) {
@@ -134,7 +134,7 @@ Table.prototype.update = function(fields, where, next){
   var f = [];
   var seed = 0;
   _.each(fields, function(value, key) {
-    f.push(key + ' = ' + "$" + (++seed));
+    f.push(util.format('"%s" = $%s', key, (++seed)));
     parameters.push(value);
   });
   // var parsedWhere = parseWhere(where);

--- a/lib/table.js
+++ b/lib/table.js
@@ -114,8 +114,8 @@ Table.prototype.insert = function(data, next) {
   if(!data) throw "insert should be called with data";
   if (!_.isArray(data)) { data = [data]; }
 
-  var delimitedKeys = _.map(_.keys(data[0]), function(key){return util.format('"%s"', key);});
-  var sql = util.format("INSERT INTO %s (%s) VALUES\n", this.delimitedFullName, delimitedKeys.join(", "));
+  var delimitedColumnNames = _.map(_.keys(data[0]), function(key){return util.format('"%s"', key);});
+  var sql = util.format("INSERT INTO %s (%s) VALUES\n", this.delimitedFullName, delimitedColumnNames.join(", "));
   var parameters = [];
   var values = []
   for(var i = 0, seed = 0; i < data.length; ++i) {

--- a/test/db/schema.sql
+++ b/test/db/schema.sql
@@ -6,6 +6,7 @@ drop table if exists docs;
 create table "Users"(
   "Id" serial primary key,
   "Email" varchar(50) not null,
+  "Name" varchar(50) not null,
   search tsvector
 );
 
@@ -26,8 +27,8 @@ create table docs(
 
 
 
-insert into "Users"("Email")
-values('test@test.com');
+insert into "Users"("Email", "Name")
+values('test@test.com', 'A test user');
 
 insert into products(name, price, description, in_stock)
 values ('Product 1', 12.00, 'Product 1 description', true),

--- a/test/table_spec.js
+++ b/test/table_spec.js
@@ -230,6 +230,24 @@ describe('Tables', function () {
         done();
       });
     });
+    it('counts all funny cased users', function (done) {
+      db.Users.count(null, null, function(err, res){
+        assert.equal(res, 1);
+        done();
+      });
+    });
+    it('counts funny cased users when we use a where and delimit the condition', function (done) {
+      db.Users.count('"Email"=$1', ["test@test.com"], function(err, res){
+        assert.equal(res, 1);
+        done();
+      });
+    });
+    it('returns users when we use a simple where', function (done) {
+      db.Users.where('"Email"=$1', ["test@test.com"], function(err, res){
+        assert.equal(res.length, 1);
+        done();
+      });
+    });
   });
   describe('Full Text search', function () {
     it('returns 3 products for term "product"', function (done) {

--- a/test/table_spec.js
+++ b/test/table_spec.js
@@ -39,7 +39,7 @@ describe('Tables -Add/Edit/Delete', function () {
       });
     });
   });
-  
+
   describe('Add/Update/Delete records with nonstandard casing:', function() {
     it('adds a User ', function (done) {
       db.Users.save({Email : "foo@bar.com"}, function(err, res){

--- a/test/table_spec.js
+++ b/test/table_spec.js
@@ -256,7 +256,7 @@ describe('Tables', function () {
         });
       });
       it('updates a User ', function (done) {
-        db.Users.save({Id : 2, '"Email"' : "bar@foo.com"}, function(err, res){
+        db.Users.save({Id : 2, Email : "bar@foo.com"}, function(err, res){
           // Update returns an array
           assert.equal(res[0].Email, "bar@foo.com");
           done();

--- a/test/table_spec.js
+++ b/test/table_spec.js
@@ -42,7 +42,7 @@ describe('Tables -Add/Edit/Delete', function () {
 
   describe('Add/Update/Delete records with nonstandard casing:', function() {
     it('adds a User ', function (done) {
-      db.Users.save({Email : "foo@bar.com"}, function(err, res){
+      db.Users.save({Email : "foo@bar.com", Name: "Another test user"}, function(err, res){
         assert.equal(res.Id, 2);
         assert.equal(res.Email, "foo@bar.com");
         done();
@@ -283,6 +283,12 @@ describe('Tables', function () {
     });
     it('returns 1 products for term "3"', function (done) {
       db.products.search({columns : ["name"], term: "3"},function(err,res){
+        assert.equal(res.length,1);
+        done();
+      });
+    });
+    it('returns 1 Users for term "test"', function (done) {
+      db.Users.search({columns : ["Name"], term: "test"},function(err,res){
         assert.equal(res.length,1);
         done();
       });

--- a/test/table_spec.js
+++ b/test/table_spec.js
@@ -39,7 +39,6 @@ describe('Tables -Add/Edit/Delete', function () {
       });
     });
   });
-
 });
 
 describe('Tables', function () {
@@ -246,6 +245,31 @@ describe('Tables', function () {
       db.Users.where('"Email"=$1', ["test@test.com"], function(err, res){
         assert.equal(res.length, 1);
         done();
+      });
+    });
+    describe('Add/Update/Delete records with nonstandard casing:', function() {
+      it('adds a User ', function (done) {
+        db.Users.save({Email : "foo@bar.com"}, function(err, res){
+          assert.equal(res.Id, 2);
+          assert.equal(res.Email, "foo@bar.com");
+          done();
+        });
+      });
+      it('updates a User ', function (done) {
+        db.Users.save({Id : 2, '"Email"' : "bar@foo.com"}, function(err, res){
+          // Update returns an array
+          assert.equal(res[0].Email, "bar@foo.com");
+          done();
+        });
+      });
+      it('deletes a User ', function (done) {
+        db.Users.destroy({Id : 2}, function(err, deleted){
+          var remaining = db.Users.find(2, function(err, found) { 
+            //Deleted returns an array...
+            assert(found == undefined && deleted[0].Id == 2);
+            done();
+          });
+        });
       });
     });
   });

--- a/test/table_spec.js
+++ b/test/table_spec.js
@@ -39,6 +39,32 @@ describe('Tables -Add/Edit/Delete', function () {
       });
     });
   });
+  
+  describe('Add/Update/Delete records with nonstandard casing:', function() {
+    it('adds a User ', function (done) {
+      db.Users.save({Email : "foo@bar.com"}, function(err, res){
+        assert.equal(res.Id, 2);
+        assert.equal(res.Email, "foo@bar.com");
+        done();
+      });
+    });
+    it('updates a User ', function (done) {
+      db.Users.save({Id : 2, Email : "bar@foo.com"}, function(err, res){
+        // Update returns an array
+        assert.equal(res[0].Email, "bar@foo.com");
+        done();
+      });
+    });
+    it('deletes a User ', function (done) {
+      db.Users.destroy({Id : 2}, function(err, deleted){
+        var remaining = db.Users.find(2, function(err, found) { 
+          //Deleted returns an array...
+          assert(found == undefined && deleted[0].Id == 2);
+          done();
+        });
+      });
+    });
+  });
 });
 
 describe('Tables', function () {
@@ -245,31 +271,6 @@ describe('Tables', function () {
       db.Users.where('"Email"=$1', ["test@test.com"], function(err, res){
         assert.equal(res.length, 1);
         done();
-      });
-    });
-    describe('Add/Update/Delete records with nonstandard casing:', function() {
-      it('adds a User ', function (done) {
-        db.Users.save({Email : "foo@bar.com"}, function(err, res){
-          assert.equal(res.Id, 2);
-          assert.equal(res.Email, "foo@bar.com");
-          done();
-        });
-      });
-      it('updates a User ', function (done) {
-        db.Users.save({Id : 2, Email : "bar@foo.com"}, function(err, res){
-          // Update returns an array
-          assert.equal(res[0].Email, "bar@foo.com");
-          done();
-        });
-      });
-      it('deletes a User ', function (done) {
-        db.Users.destroy({Id : 2}, function(err, deleted){
-          var remaining = db.Users.find(2, function(err, found) { 
-            //Deleted returns an array...
-            assert(found == undefined && deleted[0].Id == 2);
-            done();
-          });
-        });
       });
     });
   });


### PR DESCRIPTION
Related to #26.
This PR makes the table API functions; count, where, save, destroy, search, play nicely when our DB objects are non PG idiomatically cased.