### PR TITLE
Correctly get Primary Key when loading tables

### DIFF
--- a/lib/scripts/tables.sql
+++ b/lib/scripts/tables.sql
@@ -2,7 +2,8 @@ select tc.table_schema as schema, tc.table_name as name, kc.column_name as pk
 from 
     information_schema.table_constraints tc
     join information_schema.key_column_usage kc 
-        on kc.table_name = tc.table_name
+        on kc.table_name = tc.table_name and
+           kc.constraint_name = tc.constraint_name
 where 
     tc.constraint_type = 'PRIMARY KEY'
 order by tc.table_schema,


### PR DESCRIPTION
When foreign keys and unique constraints were present, the primary key would be incorrect.