### PR TITLE
replace path.parsed with path.extname and path.basename

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,10 +141,11 @@ var walkSqlFiles = function(rootObject, rootDir){
   _.each(dirs, function(item){
 
     //parsing with path is a friendly way to get info about this dir or file
-    var parsed = path.parse(item);
+    var ext = path.extname(item);
+    var name = path.basename(item, ext);
 
     //is this a SQL file?
-    if(parsed.ext === ".sql"){
+    if(ext === ".sql"){
 
       //why yes it is! Build the abspath so we can read the file
       var filePath = path.join(rootDir,item);
@@ -154,7 +155,7 @@ var walkSqlFiles = function(rootObject, rootDir){
       var sql = fs.readFileSync(filePath, {encoding : "utf-8"});
 
       //set a property on our root object, and grab a handy variable reference:
-      var newProperty = assignScriptAsFunction(rootObject, parsed.name);
+      var newProperty = assignScriptAsFunction(rootObject, name);
 
       //I don't know what I'm doing, but it works
       newProperty.sql = sql;
@@ -162,20 +163,20 @@ var walkSqlFiles = function(rootObject, rootDir){
       newProperty.filePath = filePath;
       self.queryFiles.push(newProperty);
 
-    }else if(parsed.ext !== ''){
+    }else if(ext !== ''){
       //ignore it
     }else{
 
       //this is a directory so shift things and move on down
       //set a property on our root object, then use *that*
       //as the root in the next call
-      rootObject[parsed.name] = {};
+      rootObject[name] = {};
 
       //set the path to walk so we have a correct root directory
       var pathToWalk = path.join(rootDir,item);
 
       //recursive call - do it all again
-      walkSqlFiles(rootObject[parsed.name],pathToWalk);
+      walkSqlFiles(rootObject[name],pathToWalk);
     }
   });
 }


### PR DESCRIPTION
This change will allow massive to work with node 0.10 (and probably lower as well).

`path.extname` and `path.basename` provide the same functionality as `path.parsed`. For more details see

docs for node 0.12:
https://nodejs.org/api/path.html

docs for node 0.10:
https://nodejs.org/docs/v0.10.35/api/path.html