### PR TITLE
expose pg.end to close connections immediately

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -15,7 +15,7 @@ DB.prototype.query = function () {
   //we expect sql, options, params and a callback
   var args = ArgTypes.queryArgs(arguments);
 
-  //check to see if the params are an array, which they need to be 
+  //check to see if the params are an array, which they need to be
   //for the pg module
   if(_.isObject(args.params)){
     //we only need the values from the object,
@@ -63,7 +63,7 @@ DB.prototype.stream = function () {
   //we expect sql, options, params and a callback
   var args = ArgTypes.queryArgs(arguments);
 
-  //check to see if the params are an array, which they need to be 
+  //check to see if the params are an array, which they need to be
   //for the pg module
   if(_.isObject(args.params)){
     //we only need the values from the object,
@@ -96,7 +96,10 @@ DB.prototype.executeSqlFile = function(args,next){
   self.query({sql:fileSql, params: args.params, next: next});
 };
 
-
+// close connections immediately
+DB.prototype.end = function(){
+  pg.end();
+};
 
 
 module.exports = DB;


### PR DESCRIPTION
This will allow users to manually clear the pg client pool.

On my case, it helps to prevent my test suite from hanging. But it might also help solve issues like #105 without having to exit the process.