### PR TITLE
Update deasync.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "async": "^0.9.0",
     "clone": "^1.0.2",
     "commander": "^2.6.0",
-    "deasync": "^0.0.10",
+    "deasync": "^0.1.0",
     "glob": "^4.4.1",
     "pg": "^4.3.0",
     "pg-query-stream": "^0.7.0",


### PR DESCRIPTION
See #110 and #115.

I'm running a project from my fork, but haven't actually done any DB stuff in it yet  - can't tell you if this breaks everything horribly or not.  I tried running the tests in my fork with iojs 3.3.0 and they all failed.  But then I tried running the tests with the latest pre-4.0 node version the other day and they all failed with that too.  I feel like I'm Doing It Wrong™, that somebody would have noticed if all the tests were failing.

Anyway, I can confirm that the latest version of `deasync` builds just fine with the new 4.0.0 release of node and iojs 3.3.0.