### PR TITLE
Fix syntax error in strict mode.

### DIFF
--- a/lib/arg_types.js
+++ b/lib/arg_types.js
@@ -4,7 +4,7 @@ var _ = require("underscore")._;
 //TODO: Duplication in here, DRY it up...
 
 //A Wrapper for arguments used with Table.query
-exports.queryArgs = function(arguments){
+exports.queryArgs = function(args){
   var args = Args([
     {sql : Args.STRING | Args.Required},
     {params : Args.ARRAY | Args.Optional, _default : []},
@@ -13,13 +13,13 @@ exports.queryArgs = function(arguments){
       if(err) console.log(err);
       else console.log(res);
     }}
-  ], arguments);
+  ], args);
   if(!_.isArray(args.params)) args.params = [args.params];
   return args;
 }
 
 //Used with Table.where and Table.count
-exports.whereArgs = function(arguments){
+exports.whereArgs = function(args){
   var args = Args([
     {where : Args.STRING | Args.Optional, _default : "1=1"},
     {params : Args.ANY | Args.Optional, _default : []},
@@ -27,14 +27,14 @@ exports.whereArgs = function(arguments){
       if(err) console.log(err)
       else console.log(res)
     }}
-  ], arguments);
+  ], args);
   if(!_.isArray(args.params)) args.params = [args.params];
 
   return args;
 }
 
 //Used with Table.find
-exports.findArgs = function(arguments){
+exports.findArgs = function(args){
   return Args([
     {conditions : Args.ANY | Args.Optional, _default : {}},
     {options : Args.OBJECT | Args.Optional, _default : {}},
@@ -42,5 +42,5 @@ exports.findArgs = function(arguments){
       if(err) console.log(err)
       else console.log(res)
     }}
-  ], arguments);
+  ], args);
 }


### PR DESCRIPTION
Functions in `lib/args_types.js` use the reserved word `arguments` as a variable name which results in a syntax error when running in strict mode. Renamed the variable to `args` (in line with other functions in the library) in order to support strict mode.