### PR TITLE
fix exception when finding by a string primitive pk

### DIFF
--- a/lib/queryable.js
+++ b/lib/queryable.js
@@ -120,7 +120,7 @@ Queryable.prototype.find = function(){
   limit = " limit " + args.options.limit;
   offset = " offset " + args.options.offset;
 
-  if(_.isNumber(args.conditions)){
+  if(_.isNumber(args.conditions) || _.isString(args.conditions)) {
     //a primary key search
     var newArgs = {};
     newArgs[this.primaryKeyName()] = args.conditions;

--- a/test/load_filter_spec.js
+++ b/test/load_filter_spec.js
@@ -2,24 +2,23 @@ var assert = require("assert");
 var helpers = require("./helpers");
 var massive = require("../index");
 
-var constr = "postgres://rob:password@localhost/massive";
 var path = require("path");
 var scriptsDir = path.join(__dirname, ".", "db");
 
-// JA NOTE: These tests run a little slower then most because we are connecting and 
-// re-loading the db with each test. 
+// JA NOTE: These tests run a little slower then most because we are connecting and
+// re-loading the db with each test.
 
 // JA NOTE: These tests can probably be improved - they seem fragile, and may not test
-// enough cases. 
+// enough cases.
 
 describe('On Load with Schema Filters (these tests may run slow - loads db each test!!)', function () {
   before(function(done){
     helpers.resetDb(function(err,res){
       done();
     });
-  });  
-  it('loads all schema entities when no schema argument is passed', function (done) { 
-    massive.connect({connectionString: constr}, function (err, db) {
+  });
+  it('loads all schema entities when no schema argument is passed', function (done) {
+    massive.connect({connectionString: helpers.connectionString}, function (err, db) {
       assert(db);
       assert(db.products);
       assert(db.popular_products);
@@ -31,8 +30,8 @@ describe('On Load with Schema Filters (these tests may run slow - loads db each 
       done();
     });
   });
-  it('loads all schema entities when passed "all" as schema argument', function (done) { 
-    massive.connect({connectionString: constr, schema: 'all'}, function (err, db) {
+  it('loads all schema entities when passed "all" as schema argument', function (done) {
+    massive.connect({connectionString: helpers.connectionString, schema: 'all'}, function (err, db) {
       assert(db);
       assert(db.products);
       assert(db.popular_products);
@@ -44,8 +43,8 @@ describe('On Load with Schema Filters (these tests may run slow - loads db each 
       done();
     });
   });
-  it('loads only entities from specified schema when passed schema name as schema argument', function (done) { 
-    massive.connect({connectionString: constr, schema: 'myschema'}, function (err, db) { 
+  it('loads only entities from specified schema when passed schema name as schema argument', function (done) {
+    massive.connect({connectionString: helpers.connectionString, schema: 'myschema'}, function (err, db) {
       assert(db.myschema.artists);
       assert(db.myschema.top_artists);
       assert.equal(db.tables.length, 3);
@@ -53,11 +52,11 @@ describe('On Load with Schema Filters (these tests may run slow - loads db each 
       done();
     });
   });
-  it('loads only entities from public schema when passed "public" name as schema argument', function (done) { 
+  it('loads only entities from public schema when passed "public" name as schema argument', function (done) {
     // TODO - other schema may still be present until function filters are in place...
     // Can't just test for non-presence of other schema on db - gotta test for non-presence of tables
-    // from other schema. This will be cleaned up shortly. 
-    massive.connect({connectionString: constr, schema: 'public'}, function (err, db) { 
+    // from other schema. This will be cleaned up shortly.
+    massive.connect({connectionString: helpers.connectionString, schema: 'public'}, function (err, db) {
       assert(!db.myschema.artists);
       assert(db.products);
       assert.equal(db.tables.length, 4);
@@ -65,8 +64,8 @@ describe('On Load with Schema Filters (these tests may run slow - loads db each 
       done();
     });
   });
-  it('loads only entities from specified schema when passed comma-delimited list of schema names', function (done) { 
-    massive.connect({connectionString: constr, schema: ['myschema, secrets']}, function (err, db) { 
+  it('loads only entities from specified schema when passed comma-delimited list of schema names', function (done) {
+    massive.connect({connectionString: helpers.connectionString, schema: ['myschema, secrets']}, function (err, db) {
       assert(!db.products);
       assert(db.myschema.artists);
       assert(db.myschema.top_artists);
@@ -76,8 +75,8 @@ describe('On Load with Schema Filters (these tests may run slow - loads db each 
       done();
     });
   });
-  it('loads only entities from specified schema when passed an array of schema names', function (done) { 
-    massive.connect({connectionString: constr, schema: ['myschema', 'secrets']}, function (err, db) { 
+  it('loads only entities from specified schema when passed an array of schema names', function (done) {
+    massive.connect({connectionString: helpers.connectionString, schema: ['myschema', 'secrets']}, function (err, db) {
       assert(!db.products);
       assert(db.myschema.artists);
       assert(db.myschema.top_artists);
@@ -90,8 +89,8 @@ describe('On Load with Schema Filters (these tests may run slow - loads db each 
 });
 
 describe('On Load with Table blacklist (these tests may run slow - loads db each test!!)', function () {
-  it('loads all entities when no blacklist argument is provided', function (done) { 
-    massive.connect({connectionString: constr}, function (err, db) {
+  it('loads all entities when no blacklist argument is provided', function (done) {
+    massive.connect({connectionString: helpers.connectionString}, function (err, db) {
       assert(db);
       assert(db.products);
       assert(db.popular_products);
@@ -103,8 +102,8 @@ describe('On Load with Table blacklist (these tests may run slow - loads db each
       done();
     });
   });
-  it('excludes entities with name matching blacklist pattern as a string argument', function (done) { 
-    massive.connect({connectionString: constr, blacklist: "%prod%"}, function (err, db) {
+  it('excludes entities with name matching blacklist pattern as a string argument', function (done) {
+    massive.connect({connectionString: helpers.connectionString, blacklist: "%prod%"}, function (err, db) {
       assert(db);
       assert(!db.products);
       assert(!db.popular_products);
@@ -116,8 +115,8 @@ describe('On Load with Table blacklist (these tests may run slow - loads db each
       done();
     });
   });
-  it('excludes tables with name and schema matching blacklist pattern as a string argument', function (done) { 
-    massive.connect({connectionString: constr, blacklist: "secrets.__semi%"}, function (err, db) { 
+  it('excludes tables with name and schema matching blacklist pattern as a string argument', function (done) {
+    massive.connect({connectionString: helpers.connectionString, blacklist: "secrets.__semi%"}, function (err, db) {
       assert(db.products);
       assert(db.myschema.artists);
       assert(db.secrets.__secret_table);
@@ -127,8 +126,8 @@ describe('On Load with Table blacklist (these tests may run slow - loads db each
       done();
     });
   });
-  it('excludes views with name and schema matching blacklist pattern as a string argument', function (done) { 
-    massive.connect({connectionString: constr, blacklist: "myschema.top%"}, function (err, db) { 
+  it('excludes views with name and schema matching blacklist pattern as a string argument', function (done) {
+    massive.connect({connectionString: helpers.connectionString, blacklist: "myschema.top%"}, function (err, db) {
       assert(db.products);
       assert(db.myschema.artists);
       assert(!db.myschema.top_artists);
@@ -139,8 +138,8 @@ describe('On Load with Table blacklist (these tests may run slow - loads db each
       done();
     });
   });
-  it('excludes entities with name and schema matching multiiple blacklist patterns as a comma-delimited string argument', function (done) { 
-    massive.connect({connectionString: constr, blacklist: "secrets.__semi%, %prod%"}, function (err, db) { 
+  it('excludes entities with name and schema matching multiiple blacklist patterns as a comma-delimited string argument', function (done) {
+    massive.connect({connectionString: helpers.connectionString, blacklist: "secrets.__semi%, %prod%"}, function (err, db) {
       assert(!db.products);
       assert(!db.popular_products);
       assert(db.myschema.artists);
@@ -151,8 +150,8 @@ describe('On Load with Table blacklist (these tests may run slow - loads db each
       done();
     });
   });
-  it('excludes entities with name and schema matching multiple blacklist patterns as a string array argument', function (done) { 
-    massive.connect({connectionString: constr, blacklist: ['secrets.__semi%', '%prod%']}, function (err, db) { 
+  it('excludes entities with name and schema matching multiple blacklist patterns as a string array argument', function (done) {
+    massive.connect({connectionString: helpers.connectionString, blacklist: ['secrets.__semi%', '%prod%']}, function (err, db) {
       assert(!db.products);
       assert(!db.popular_products);
       assert(db.myschema.artists);
@@ -163,8 +162,8 @@ describe('On Load with Table blacklist (these tests may run slow - loads db each
       done();
     });
   });
-  it('allows table exceptions to schema filter', function (done) { 
-    massive.connect({connectionString: constr, schema: 'myschema', exceptions: 'products'}, function (err, db) {
+  it('allows table exceptions to schema filter', function (done) {
+    massive.connect({connectionString: helpers.connectionString, schema: 'myschema', exceptions: 'products'}, function (err, db) {
       assert(db.products);
       assert(db.myschema.artists);
       assert.equal(db.tables.length, 4);
@@ -173,8 +172,8 @@ describe('On Load with Table blacklist (these tests may run slow - loads db each
       done();
     });
   });
-  it('allows view exceptions to schema filter', function (done) { 
-    massive.connect({connectionString: constr, schema: 'myschema', exceptions: 'popular_products'}, function (err, db) { 
+  it('allows view exceptions to schema filter', function (done) {
+    massive.connect({connectionString: helpers.connectionString, schema: 'myschema', exceptions: 'popular_products'}, function (err, db) {
       assert(!db.products);
       assert(db.popular_products);
       assert(db.myschema.artists);
@@ -184,8 +183,8 @@ describe('On Load with Table blacklist (these tests may run slow - loads db each
       done();
     });
   });
-  it('allows exceptions to blacklist filter', function (done) { 
-    massive.connect({connectionString: constr, blacklist: 'myschema.a%', exceptions: 'myschema.artists'}, function (err, db) { 
+  it('allows exceptions to blacklist filter', function (done) {
+    massive.connect({connectionString: helpers.connectionString, blacklist: 'myschema.a%', exceptions: 'myschema.artists'}, function (err, db) {
       assert(db.products);
       assert(db.myschema.artists);
       assert.equal(db.tables.length, 8);
@@ -193,8 +192,8 @@ describe('On Load with Table blacklist (these tests may run slow - loads db each
       done();
     });
   });
-  it('allows exceptions to schema and blacklist filters', function (done) { 
-    massive.connect({connectionString: constr, schema: 'myschema', blacklist: 'secrets.__%', exceptions: 'products, secrets.__secret_table'}, function (err, db) { 
+  it('allows exceptions to schema and blacklist filters', function (done) {
+    massive.connect({connectionString: helpers.connectionString, schema: 'myschema', blacklist: 'secrets.__%', exceptions: 'products, secrets.__secret_table'}, function (err, db) {
       assert(db.products);
       assert(db.myschema.artists);
       assert(db.secrets.__secret_table);
@@ -207,32 +206,32 @@ describe('On Load with Table blacklist (these tests may run slow - loads db each
 });
 
 describe('On Load with Table whitelist (these tests may run slow - loads db each test!!)', function () {
-  it('loads all tables when no whitelist argument is provided', function (done) { 
-    massive.connect({connectionString: constr}, function (err, db) { 
+  it('loads all tables when no whitelist argument is provided', function (done) {
+    massive.connect({connectionString: helpers.connectionString}, function (err, db) {
       assert(db.products && db.myschema.artists && db.secrets.__secret_table && db.tables.length == 9);
       done();
     });
   });
-  it('includes ONLY tables with name matching whitelisted table names as a string argument', function (done) { 
-    massive.connect({connectionString: constr, whitelist: "products"}, function (err, db) { 
+  it('includes ONLY tables with name matching whitelisted table names as a string argument', function (done) {
+    massive.connect({connectionString: helpers.connectionString, whitelist: "products"}, function (err, db) {
       assert(db.products && db.tables.length == 1);
       done();
     });
   });
-  it('includes ONLY tables with name matching whitelisted items in comma-delimited string', function (done) { 
-    massive.connect({connectionString: constr, whitelist: 'products, myschema.artists'}, function (err, db) { 
+  it('includes ONLY tables with name matching whitelisted items in comma-delimited string', function (done) {
+    massive.connect({connectionString: helpers.connectionString, whitelist: 'products, myschema.artists'}, function (err, db) {
       assert(db.products && db.myschema.artists && db.tables.length == 2);
       done();
     });
   });
-  it('includes ONLY tables with name matching whitelisted items in string array', function (done) { 
-    massive.connect({connectionString: constr, whitelist: ['products', 'myschema.artists']}, function (err, db) { 
+  it('includes ONLY tables with name matching whitelisted items in string array', function (done) {
+    massive.connect({connectionString: helpers.connectionString, whitelist: ['products', 'myschema.artists']}, function (err, db) {
       assert(db.products && db.myschema.artists && db.tables.length == 2);
       done();
     });
   });
-  it('whitelist overrides other filters', function (done) { 
-    massive.connect({connectionString: constr, schema: 'myschema', blacklist: 'a%', whitelist: 'products, secrets.__secret_table'}, function (err, db) { 
+  it('whitelist overrides other filters', function (done) {
+    massive.connect({connectionString: helpers.connectionString, schema: 'myschema', blacklist: 'a%', whitelist: 'products, secrets.__secret_table'}, function (err, db) {
       assert(db.products && !db.myschema.artists && db.secrets.__secret_table && db.tables.length == 2);
       done();
     });
@@ -240,20 +239,20 @@ describe('On Load with Table whitelist (these tests may run slow - loads db each
 });
 
 describe('On load with Function Exclusion (these tests may run slow - loads db each test!!)', function () {
-  it('excludes functions at load whenever it is told...', function (done) { 
-    massive.connect({connectionString: constr, excludeFunctions: true}, function (err, db) { 
+  it('excludes functions at load whenever it is told...', function (done) {
+    massive.connect({connectionString: helpers.connectionString, excludeFunctions: true}, function (err, db) {
       assert.equal(db.functions.length, 0);
       done();
     });
   });
-  it('includes all functions at load whenever it is told...', function (done) { 
-    massive.connect({connectionString: constr, excludeFunctions: false}, function (err, db) { 
+  it('includes all functions at load whenever it is told...', function (done) {
+    massive.connect({connectionString: helpers.connectionString, excludeFunctions: false}, function (err, db) {
       assert(db.functions.length > 0);
       done();
     });
   });
-  it('includes all functions at load by default...', function (done) { 
-    massive.connect({connectionString: constr}, function (err, db) { 
+  it('includes all functions at load by default...', function (done) {
+    massive.connect({connectionString: helpers.connectionString}, function (err, db) {
       assert(db.functions.length > 0);
       done();
     });
@@ -261,32 +260,32 @@ describe('On load with Function Exclusion (these tests may run slow - loads db e
 });
 
 describe('On load with Function Blacklist (these tests may run slow - loads db each test!!)', function () {
-  it('loads all functions when no blacklist argument is provided', function (done) { 
-    massive.connect({connectionString: constr}, function (err, db) { 
+  it('loads all functions when no blacklist argument is provided', function (done) {
+    massive.connect({connectionString: helpers.connectionString}, function (err, db) {
       assert(db.AllMyProducts && db.all_products && db.myschema.AllMyAlbums && db.myschema.all_albums && db.myschema.artist_by_name);
       done();
     });
   });
-  it('excludes functions with name matching blacklist pattern as a string argument', function (done) { 
-    massive.connect({connectionString: constr, functionBlacklist: "all_%"}, function (err, db) { 
+  it('excludes functions with name matching blacklist pattern as a string argument', function (done) {
+    massive.connect({connectionString: helpers.connectionString, functionBlacklist: "all_%"}, function (err, db) {
       assert(!db.all_products && db.AllMyProducts);
       done();
     });
   });
-  it('excludes functions with name and schema matching blacklist pattern as a string argument', function (done) { 
-    massive.connect({connectionString: constr, functionBlacklist: "myschema.all_%"}, function (err, db) { 
+  it('excludes functions with name and schema matching blacklist pattern as a string argument', function (done) {
+    massive.connect({connectionString: helpers.connectionString, functionBlacklist: "myschema.all_%"}, function (err, db) {
       assert(!db.myschema.all_albums && db.myschema.artist_by_name && db.all_products);
       done();
     });
   });
-  it('excludes functions with name and schema matching multiiple blacklist patterns as a comma-delimited string argument', function (done) { 
-    massive.connect({connectionString: constr, functionBlacklist: "myschema.artist_%, all_%"}, function (err, db) { 
+  it('excludes functions with name and schema matching multiiple blacklist patterns as a comma-delimited string argument', function (done) {
+    massive.connect({connectionString: helpers.connectionString, functionBlacklist: "myschema.artist_%, all_%"}, function (err, db) {
       assert(!db.myschema.artist_by_name && !db.all_products && db.myschema.all_albums && db.AllMyProducts);
       done();
     });
   });
-  it('excludes functions with name and schema matching multiiple blacklist patterns as a string array argument', function (done) { 
-    massive.connect({connectionString: constr, functionBlacklist: ["myschema.artist_%", "all_%"]}, function (err, db) { 
+  it('excludes functions with name and schema matching multiiple blacklist patterns as a string array argument', function (done) {
+    massive.connect({connectionString: helpers.connectionString, functionBlacklist: ["myschema.artist_%", "all_%"]}, function (err, db) {
       assert(!db.myschema.artist_by_name && !db.all_products && db.myschema.all_albums && db.AllMyProducts);
       done();
     });

--- a/test/loader_spec.js
+++ b/test/loader_spec.js
@@ -3,20 +3,20 @@ var helpers = require("./helpers");
 var db;
 
 describe('On spin up', function () {
-  
+
   before(function(done){
     helpers.resetDb(function(err,res){
       db = res;
       done()
     });
-  });  
+  });
   it('returns a valid db interface', function () {
     assert(db && db.tables && db.queryFiles && db.connectionString);
   });
   it('loads non-public schema as namespace property', function() {
     assert(db.myschema, "No Schema loaded");
   });
-  it('loads tables in db schema as properties of namespace', function() { 
+  it('loads tables in db schema as properties of namespace', function() {
     assert(db.myschema.artists && db.myschema.albums, 'No tables loaded on schema')
   });
   it('loads up 7 tables with 2 in schema object in array property', function () {
@@ -33,24 +33,23 @@ describe('On spin up', function () {
 });
 
 var syncLoaded;
-var constr = "postgres://rob:password@localhost/massive";
 var path = require("path");
 var scriptsDir = path.join(__dirname, ".", "db");
 
 describe('Synchronous Load', function () {
-  
-  it('loads the db synchronously and blocks execution until complete', function() { 
+
+  it('loads the db synchronously and blocks execution until complete', function() {
     // no need to re-set the back-end; it wasn't changed by the previous 'suite' ...
-    syncLoaded = require("../index").loadSync({connectionString: constr, scripts: scriptsDir});
+    syncLoaded = require("../index").loadSync({connectionString: helpers.connectionString, scripts: scriptsDir});
     assert(syncLoaded && syncLoaded.tables && syncLoaded.queryFiles && syncLoaded.connectionString);
-  }); 
+  });
   it('returns a valid db instance from sync load function', function () {
     assert(syncLoaded && syncLoaded.tables && syncLoaded.queryFiles && syncLoaded.connectionString);
   });
   it('loads non-public schema as namespace property', function () {
     assert(syncLoaded.myschema, "No Schema loaded");
   });
-  it('loads tables in syncLoaded schema as properties of namespace', function() { 
+  it('loads tables in syncLoaded schema as properties of namespace', function() {
     assert(syncLoaded.myschema.artists && syncLoaded.myschema.albums, 'No tables loaded on schema')
   });
   it('loads up 7 tables with 2 in schema object in array property', function () {

--- a/test/queryable_spec.js
+++ b/test/queryable_spec.js
@@ -11,21 +11,6 @@ describe('Queryables', function () {
     });
   });
 
-  describe('Simple table queries with args', function () {
-    it('returns product 1 with 1 as only arg', function (done) {
-      db.products.find(1, function(err,res){
-        assert.equal(res.id, 1);
-        done();
-      });
-    });
-    it('returns first record with findOne no args', function (done) {
-      db.products.findOne(1, function(err,res){
-        assert.equal(res.id, 1);
-        done();
-      });
-    });
-  });
-
   describe('Simple table queries without args', function () {
     it('returns all records on find with no args', function (done) {
       db.products.find(function(err,res){
@@ -37,6 +22,42 @@ describe('Queryables', function () {
       db.products.findOne(function(err,res){
         assert.equal(res.id, 1);
         done();
+      });
+    });
+  });
+
+  describe('Simple table queries by primary key', function () {
+    it('finds by a numeric key and returns a result object', function (done) {
+      db.products.find(1, function(err, res) {
+        assert.equal(res.id, 1);
+        done();
+      });
+    });
+
+    it('findOnes by a numeric key and returns a result object', function (done) {
+      db.products.findOne(1, function(err, res) {
+        assert.equal(res.id, 1);
+        done();
+      });
+    });
+
+    it('finds by a string/uuid key and returns a result object', function (done) {
+      db.orders.findOne(function (err, order) {
+        assert.notStrictEqual(order, undefined);
+        db.orders.find(order.id, function(err, res) {
+          assert.equal(res.id, order.id);
+          done();
+        });
+      });
+    });
+
+    it('findOnes by a string/uuid key and returns a result object', function (done) {
+      db.orders.findOne(function (err, order) {
+        assert.notStrictEqual(order, undefined);
+        db.orders.findOne(order.id, function(err, res) {
+          assert.equal(res.id, order.id);
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
Fixes #159 

also makes a couple other tests use the connection string in helpers to avoid having to change that multiple places.