### PR TITLE
Fix update when no fields are passed

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -59,7 +59,16 @@ Table.prototype.update = function(conditions, fields, next) {
     options.single = true;
   }
 
-  if(_.isObject(fields) === false) throw "Update requires a hash of fields=>values to update to";
+  assert(_.isObject(fields), "Update requires a hash of fields=>values to update to");
+
+  if (_.isEmpty(fields)) {
+    // there's nothing to update, so just return the matching records
+    if (options.single) {
+      return this.findOne(conditions, next);
+    } else {
+      return this.find(conditions, next);
+    }
+  }
 
   var parameters = [];
   var f = [];

--- a/test/table_spec.js
+++ b/test/table_spec.js
@@ -99,7 +99,25 @@ describe('Tables -Add/Edit/Delete', function () {
       });
     });
 
-    it('deletes a product', function (done) {
+    it('returns a product when there are no fields to be updated', function (done) {
+      db.products.update({id: 1}, function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.id, 1);
+        assert.equal(res.name, 'Product 1');
+        done();
+      });
+    });
+
+    it('returns multiple products when there are no fields to be updated', function (done) {
+      db.products.update({id: [1, 2]}, {}, function(err, res) {
+        assert.ifError(err);
+        assert.equal(res[0].id, 1);
+        assert.equal(res[0].name, 'Product 1');
+        done();
+      });
+    });
+    
+    it('deletes a product ', function (done) {
       db.products.destroy({id : 4}, function(err, deleted){
         db.products.find(4, function(err, found) {
           assert.ifError(err);


### PR DESCRIPTION
Proposed fix for #166.

When there are no fields included in an update, just return the matching records without attempting an update.

An alternative approach would be to just return an error when there are no fields to update. Let me know which option sounds best.