### PR TITLE
Document setAttribute to update document using Postgresql 9.5's jsonb_set

### DIFF
--- a/lib/document_table.js
+++ b/lib/document_table.js
@@ -58,7 +58,7 @@ exports.saveDocSync = DA(this.saveDoc);
 exports.updateDoc = function(id, key, val, next){
   const pkName = this.primaryKeyName();
   const params = ["{"+key+"}", val, id];
-  var sql = util.format("update %s set body=jsonb_set(body, $1, $2, true) where %s = $3 returning *;", this.fullname, pkName);
+  const sql = util.format("update %s set body=jsonb_set(body, $1, $2, true) where %s = $3 returning *;", this.fullname, pkName);
   this.executeDocQuery(sql, params, {single:true}, next);
 }
 exports.updateDocSync = DA(this.updateDoc);

--- a/lib/document_table.js
+++ b/lib/document_table.js
@@ -54,6 +54,22 @@ exports.saveDoc = function(args, next){
 };
 exports.saveDocSync = DA(this.saveDoc);
 
+// XXX: Only works for jsonb column type and Postgresql 9.5
+exports.updateDoc = function(args, next){
+  assert(_.isObject(args), "Please pass in the document for saving as an object. Include the primary key for an UPDATE.");
+  const self = this;
+  var sql, params = [];
+  const pkName = this.primaryKeyName;
+  const plVal = args[pkName];
+
+  delete args[pkName];
+  params.push(JSON.stringify(args));
+
+  sql = util.format("update %s set body=jsonb_set(body, $1, true) where %s = $2 returning *;", this.fullname, pkName);
+  this.executeDocQuery(sql, params, {single:true}, next);
+}
+exports.updateDocSync = DA(this.updateDoc);
+
 exports.findDoc = function(){
   var args = ArgTypes.findArgs(arguments);
   if(_.isFunction(args.conditions)){

--- a/lib/document_table.js
+++ b/lib/document_table.js
@@ -54,12 +54,11 @@ exports.saveDoc = function(args, next){
 };
 exports.saveDocSync = DA(this.saveDoc);
 
-// XXX: Only works for jsonb column type and Postgresql 9.5
+// Only works for jsonb column type and Postgresql 9.5
 exports.updateDoc = function(args, next){
-  assert(_.isObject(args), "Please pass in the document for saving as an object. Include the primary key for an UPDATE.");
+  assert(_.isObject(args), "Please pass in the document including pk.");
   var sql, params = [];
   const pkName = this.primaryKeyName;
-  const plVal = args[pkName];
 
   delete args[pkName];
   params.push(JSON.stringify(args));

--- a/lib/document_table.js
+++ b/lib/document_table.js
@@ -55,15 +55,10 @@ exports.saveDoc = function(args, next){
 exports.saveDocSync = DA(this.saveDoc);
 
 // Only works for jsonb column type and Postgresql 9.5
-exports.updateDoc = function(args, next){
-  assert(_.isObject(args), "Please pass in the document including pk.");
-  var sql, params = [];
-  const pkName = this.primaryKeyName;
-
-  delete args[pkName];
-  params.push(JSON.stringify(args));
-
-  sql = util.format("update %s set body=jsonb_set(body, $1, true) where %s = $2 returning *;", this.fullname, pkName);
+exports.updateDoc = function(id, key, val, next){
+  const pkName = this.primaryKeyName();
+  const params = ["{"+key+"}", val, id];
+  var sql = util.format("update %s set body=jsonb_set(body, $1, $2, true) where %s = $3 returning *;", this.fullname, pkName);
   this.executeDocQuery(sql, params, {single:true}, next);
 }
 exports.updateDocSync = DA(this.updateDoc);

--- a/lib/document_table.js
+++ b/lib/document_table.js
@@ -55,7 +55,7 @@ exports.saveDoc = function(args, next){
 exports.saveDocSync = DA(this.saveDoc);
 
 // Only works for jsonb column type and Postgresql 9.5
-exports.updateDoc = function(id, key, val, next){
+exports.setAttribute = function(id, key, val, next){
   const pkName = this.primaryKeyName();
   const params = ["{"+key+"}", val, id];
   const sql = util.format("update %s set body=jsonb_set(body, $1, $2, true) where %s = $3 returning *;", this.fullname, pkName);

--- a/lib/document_table.js
+++ b/lib/document_table.js
@@ -57,7 +57,6 @@ exports.saveDocSync = DA(this.saveDoc);
 // XXX: Only works for jsonb column type and Postgresql 9.5
 exports.updateDoc = function(args, next){
   assert(_.isObject(args), "Please pass in the document for saving as an object. Include the primary key for an UPDATE.");
-  const self = this;
   var sql, params = [];
   const pkName = this.primaryKeyName;
   const plVal = args[pkName];

--- a/test/document_update_spec.js
+++ b/test/document_update_spec.js
@@ -26,7 +26,7 @@ describe('Document updates,', function(){
     it('check saved attribute', function(){
       assert.equal(1, newDoc.score);
     });
-    it('updates the document', function() {
+    it('updates the document', function(done) {
       db.doggies.updateDoc(newDoc.id, "vaccinated", true, function(err, doc){
         assert.equal(doc.vaccinated, true);
         done();

--- a/test/document_update_spec.js
+++ b/test/document_update_spec.js
@@ -1,0 +1,46 @@
+var assert = require("assert");
+var helpers = require("./helpers");
+var db;
+
+describe('Document updates,', function(){
+
+  before(function(done){
+    helpers.resetDb(function(err, res){
+      db = res;
+      done();
+    });
+  });
+
+// update objects set body=jsonb_set(body, '{name,last}', '', true) where id=3;
+  describe("Save data and update,", function() {
+    var newDoc = {};
+    before(function(done) {
+      db.saveDoc("doggies", {name:"Foo", score:1}, function(err, doc){
+        newDoc = doc;
+        done();
+      });
+    });
+    it('creates the table', function(){
+      assert(db.doggies);
+    });
+    it('check saved attribute', function(){
+      assert.equal(1, newDoc.score);
+    });
+    it('updates the document', function() {
+      db.doggies.updateDoc(newDoc.id, "vaccinated", true, function(err, doc){
+        assert.equal(doc.vaccinated, true);
+        done();
+      });
+    });
+    it('updates the document without replacing existing attributes', function(done) {
+      db.doggies.updateDoc(newDoc.id, "score", 10, function(err, doc){
+        assert.equal(doc.score, 10);
+        assert.equal(doc.vaccinated, true);
+        assert.equal(doc.id, newDoc.id);
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/document_update_spec.js
+++ b/test/document_update_spec.js
@@ -27,14 +27,14 @@ describe('Document updates,', function(){
       assert.equal(1, newDoc.score);
     });
     it('updates the document', function(done) {
-      db.doggies.updateDoc(newDoc.id, "vaccinated", true, function(err, doc){
+      db.doggies.setAttribute(newDoc.id, "vaccinated", true, function(err, doc){
         assert.equal(doc.vaccinated, true);
         done();
       });
     });
     it('updates the document without replacing existing attributes', function(done) {
-      db.doggies.updateDoc(newDoc.id, "score", 10, function(err, doc){
-        assert.equal(doc.score, 10);
+      db.doggies.setAttribute(newDoc.id, "score", 99, function(err, doc){
+        assert.equal(doc.score, 99);
         assert.equal(doc.vaccinated, true);
         assert.equal(doc.id, newDoc.id);
         done();

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -17,7 +17,7 @@ exports.resetDb = function(next){
     assert(!err,err);
     db.schema(function(err, res){
       assert(!err,err);
-      next(null,db);
+      next(null, db);
     });
   });
 };


### PR DESCRIPTION
Make use of Postgresql 9.5's jsonb_set to update a document attribute.
Will append if key is not found -- may need to revisit this default behavior.