### PR TITLE
fix backwards-compatibility for node < 4, fix test pollution

### DIFF
--- a/lib/document_table.js
+++ b/lib/document_table.js
@@ -56,11 +56,11 @@ exports.saveDocSync = DA(this.saveDoc);
 
 // Only works for jsonb column type and Postgresql 9.5
 exports.setAttribute = function(id, key, val, next){
-  const pkName = this.primaryKeyName();
-  const params = ["{"+key+"}", val, id];
-  const sql = util.format("update %s set body=jsonb_set(body, $1, $2, true) where %s = $3 returning *;", this.fullname, pkName);
+  var pkName = this.primaryKeyName();
+  var params = ["{"+key+"}", val, id];
+  var sql = util.format("update %s set body=jsonb_set(body, $1, $2, true) where %s = $3 returning *;", this.fullname, pkName);
   this.executeDocQuery(sql, params, {single:true}, next);
-}
+};
 exports.updateDocSync = DA(this.updateDoc);
 
 exports.findDoc = function(){

--- a/lib/where.js
+++ b/lib/where.js
@@ -43,7 +43,7 @@ exports.parseKey = function (key) {
     // fix for #>>
     // this is totally a hack but it's not going to get much better without
     // building a full-fledged parser
-    if (jsonOp.endsWith('{') && parts.length > 0) {
+    if (jsonOp.lastIndexOf('{') === jsonOp.length - 1 && parts.length > 0) {
       jsonOp = '#>>';   // opening brace is otherwise part of jsonOp since there aren't word boundaries between them
 
       while (parts[1]) {  // go until there's one left, that'll be the closing brace and any operation

--- a/test/document_update_spec.js
+++ b/test/document_update_spec.js
@@ -1,8 +1,8 @@
 var assert = require("assert");
 var helpers = require("./helpers");
-var db;
 
 describe('Document updates,', function(){
+  var db;
 
   before(function(done){
     helpers.resetDb(function(err, res){
@@ -11,29 +11,29 @@ describe('Document updates,', function(){
     });
   });
 
-// update objects set body=jsonb_set(body, '{name,last}', '', true) where id=3;
+  // update objects set body=jsonb_set(body, '{name,last}', '', true) where id=3;
   describe("Save data and update,", function() {
     var newDoc = {};
     before(function(done) {
-      db.saveDoc("doggies", {name:"Foo", score:1}, function(err, doc){
+      db.saveDoc("docs", {name:"Foo", score:1}, function(err, doc){
         newDoc = doc;
         done();
       });
     });
-    it('creates the table', function(){
-      assert(db.doggies);
-    });
+
     it('check saved attribute', function(){
       assert.equal(1, newDoc.score);
     });
+
     it('updates the document', function(done) {
-      db.doggies.setAttribute(newDoc.id, "vaccinated", true, function(err, doc){
+      db.docs.setAttribute(newDoc.id, "vaccinated", true, function(err, doc){
         assert.equal(doc.vaccinated, true);
         done();
       });
     });
+
     it('updates the document without replacing existing attributes', function(done) {
-      db.doggies.setAttribute(newDoc.id, "score", 99, function(err, doc){
+      db.docs.setAttribute(newDoc.id, "score", 99, function(err, doc){
         assert.equal(doc.score, 99);
         assert.equal(doc.vaccinated, true);
         assert.equal(doc.id, newDoc.id);
@@ -41,6 +41,8 @@ describe('Document updates,', function(){
       });
     });
 
+    after(function (done) {
+      db.docs.destroy({id: newDoc.id}, done);
+    });
   });
-
 });


### PR DESCRIPTION
I'm still getting two test failures in the function loader test (& the sync version) where it's reporting an extra function being loaded. Since I just upgraded my system to 9.5, I suspect that's probably the cause -- I'd appreciate it if someone else could pull it down and confirm, juggling versions with homebrew is no fun at all.