### PR TITLE
Add Travis badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ## Massive 2.0: A Postgres-centric Data Access Tool
 
+[![Build Status](https://travis-ci.org/robconery/massive-js.svg?branch=master)](https://travis-ci.org/robconery/massive-js)
+
 *This is the repository for MassiveJS 2.0. If you're looking for < 2, [you can find it here](https://github.com/robconery/massive-js/releases/tag/1.0)*
 
 Massive's goal is to **help** you get data from your database. This is not an ORM, it's a bit more than a query tool - our goal is to do just enough, then get out of your way. [I'm a huge fan of Postgres](http://rob.conery.io/category/postgres/) and the inspired, creative way you can use it's modern SQL functionality to work with your data.


### PR DESCRIPTION
Puts the build status on the front page of the project.

Should go green once the Travis tests are enabled. Looks like the repository still needs to be enabled in Travis as documented here https://docs.travis-ci.com/user/getting-started/.