### PR TITLE
Add error checks to tests

### DIFF
--- a/test/document_update_spec.js
+++ b/test/document_update_spec.js
@@ -27,6 +27,7 @@ describe('Document updates,', function(){
 
     it('updates the document', function(done) {
       db.docs.setAttribute(newDoc.id, "vaccinated", true, function(err, doc){
+        assert.ifError(err);
         assert.equal(doc.vaccinated, true);
         done();
       });


### PR DESCRIPTION
I've noticed that errors returned in callbacks are generally ignored in the tests. This can make it hard to work out why a test is failing.

Here's the output of a currently failing test:

```
  1) Document updates, Save data and update, updates the document:
     Uncaught TypeError: Cannot read property 'vaccinated' of null
      at Object.next (test/document_update_spec.js:30:25)
      at Object.next (lib/document_table.js:131:12)
      at null.callback (lib/runner.js:53:16)
      at Query.handleError (node_modules/pg/lib/query.js:106:17)
      at null.<anonymous> (node_modules/pg/lib/client.js:171:26)
      at Socket.<anonymous> (node_modules/pg/lib/connection.js:109:12)
      at readableAddChunk (_stream_readable.js:146:16)
      at Socket.Readable.push (_stream_readable.js:110:10)
      at TCP.onread (net.js:523:20)
```

It's trying to access a property on `null` because there's actually an error that's being ignored. Running the tests again after adding the error check in this PR:

```
  1) Document updates, Save data and update, updates the document:
     Uncaught Error: function jsonb_set(jsonb, unknown, unknown, boolean) does not exist
      at DB.query (lib/runner.js:17:11)
      at __dirname.executeDocQuery (lib/document_table.js:129:11)
      at exports.setAttribute (lib/document_table.js:62:8)
      at Context.<anonymous> (test/document_update_spec.js:29:15)
```

Which reveals that `jsonb_set` is missing from my Postgres install (it's in 9.5 but not 9.4) and is the reason for the failure.

If people like the idea of error checking in tests, I'll keep this PR open and update them all. I've just included one as an example.