### PR TITLE
Run 9.5 tests conditionally based on Postgres version

### DIFF
--- a/test/document_update_spec.js
+++ b/test/document_update_spec.js
@@ -1,5 +1,6 @@
 var assert = require("assert");
 var helpers = require("./helpers");
+var skipBelow95 = require("./helpers/versions").skipBelow95;
 
 describe('Document updates,', function(){
   var db;
@@ -22,11 +23,11 @@ describe('Document updates,', function(){
       });
     });
 
-    it('check saved attribute', function(){
+    skipBelow95('check saved attribute', function(){
       assert.equal(1, newDoc.score);
     });
 
-    it('updates the document', function(done) {
+    skipBelow95('updates the document', function(done) {
       db.docs.setAttribute(newDoc.id, "vaccinated", true, function(err, doc){
         assert.ifError(err);
         assert.equal(doc.vaccinated, true);
@@ -34,7 +35,7 @@ describe('Document updates,', function(){
       });
     });
 
-    it('updates the document without replacing existing attributes', function(done) {
+    skipBelow95('updates the document without replacing existing attributes', function(done) {
       db.docs.setAttribute(newDoc.id, "score", 99, function(err, doc){
         assert.ifError(err);
         assert.equal(doc.score, 99);

--- a/test/helpers/versions.js
+++ b/test/helpers/versions.js
@@ -1,0 +1,29 @@
+var helpers = require('./index');
+var massive = require('../../index');
+var connectionString = helpers.connectionString;
+var gte95;
+
+function init() {
+  var db = massive.connectSync({
+    connectionString: connectionString
+  });
+  var res = db.runSync('SELECT version()');
+  var version = res[0].version;
+  var matches = version.match(/PostgreSQL (\d+)\.(\d+)/);
+  var major = parseInt(matches[1]);
+  var minor = parseInt(matches[2]);
+
+  gte95 = (major >= 9 && minor >= 5);
+}
+
+module.exports.skipBelow95 = function () {
+  var args = Array.prototype.slice.call(arguments);
+
+  if (gte95) {
+    it.apply(null, args);
+  } else {
+    it.skip.apply(null, args);
+  }
+};
+
+init();

--- a/test/loader_spec.js
+++ b/test/loader_spec.js
@@ -28,7 +28,8 @@ describe('On spin up', function () {
     assert.equal(db.queryFiles.length, 7);
   });
   it('loads up functions', function () {
-    assert.equal(db.functions.length, 20);
+    // newer versions of postgres include more than 20 functions
+    assert.ok(db.functions.length >= 20);
   });
 });
 
@@ -61,6 +62,7 @@ describe('Synchronous Load', function () {
     assert.equal(syncLoaded.queryFiles.length, 7);
   });
   it('loads up functions', function () {
-    assert.equal(syncLoaded.functions.length, 20);
+    // newer versions of postgres include more than 20 functions
+    assert.ok(syncLoaded.functions.length >= 20);
   });
 });


### PR DESCRIPTION
* Checks the Postgres version on startup
* Initial check uses `sync` methods to avoid callback order issues
* Uses Mocha's `skip` method to skip tests
* Still need to document 9.5-only features as a separate task
* Travis tests now passing :+1: 

Fixes #189 