### PR TITLE
Query runner error details added

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -50,7 +50,7 @@ DB.prototype.query = function () {
             e.message = err.message || err.toString();
           }
 
-          args.next(_.defaults(err, e), null);
+          args.next(_.defaults(e, err), null);
         } else {
           //only return one result if single is sent in
           if (args.options.single) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -50,7 +50,7 @@ DB.prototype.query = function () {
             e.message = err.message || err.toString();
           }
 
-          args.next(e, null);
+          args.next(_.defaults(err, e), null);
         } else {
           //only return one result if single is sent in
           if (args.options.single) {


### PR DESCRIPTION
Currently the query runner error contains only a `message` property which makes it really hard to create error specific handlers. (such as a duplicate error, foreign key constraint etc.)

Looking through the commit history I saw that this was a side-effect of stacktrace improvement done back in august. By simply extending the error object we get to keep both the useful stack and all the other properties.