### PR TITLE
Renamed updateDocSync to setAttributeSync and added test for that method

### DIFF
--- a/lib/document_table.js
+++ b/lib/document_table.js
@@ -61,7 +61,7 @@ exports.setAttribute = function(id, key, val, next){
   const sql = util.format("update %s set body=jsonb_set(body, $1, $2, true) where %s = $3 returning *;", this.fullname, pkName);
   this.executeDocQuery(sql, params, {single:true}, next);
 }
-exports.updateDocSync = DA(this.updateDoc);
+exports.setAttributeSync= DA(this.setAttribute);
 
 exports.findDoc = function(){
   var args = ArgTypes.findArgs(arguments);

--- a/test/document_attribute_manipulation_spec.js
+++ b/test/document_attribute_manipulation_spec.js
@@ -2,7 +2,7 @@ var assert = require("assert");
 var helpers = require("./helpers");
 var db;
 
-describe('Document updates,', function(){
+describe('Document attribute manipulation,', function(){
 
   before(function(done){
     helpers.resetDb(function(err, res){
@@ -26,19 +26,25 @@ describe('Document updates,', function(){
     it('check saved attribute', function(){
       assert.equal(1, newDoc.score);
     });
-    it('updates the document', function(done) {
+    it('updates the document attribute', function(done) {
       db.doggies.setAttribute(newDoc.id, "vaccinated", true, function(err, doc){
         assert.equal(doc.vaccinated, true);
         done();
       });
     });
-    it('updates the document without replacing existing attributes', function(done) {
+    it('updates the document attribute without overwriting', function(done) {
       db.doggies.setAttribute(newDoc.id, "score", 99, function(err, doc){
         assert.equal(doc.score, 99);
         assert.equal(doc.vaccinated, true);
         assert.equal(doc.id, newDoc.id);
         done();
       });
+    });
+    it('updates the document attribute using sync method', function(done) {
+      var doc = db.doggies.setAttributeSync(newDoc.id, "score", 101);
+        assert.equal(doc.score, 101);
+        assert.equal(doc.id, newDoc.id);
+        done();
     });
 
   });


### PR DESCRIPTION
Changes:
- Renamed the wrong 'updateDocSync' method name to setAttributeSync
- Renamed test/{document_update_spec.js => document_attribute_manipulation_spec.js}
- Updated test description to make it clear we are manipulating attribute and no updating the document