### PR TITLE
Added "toString"-option, allows Massive to return generated sql without executing it

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -16,6 +16,9 @@ DB.prototype.query = function () {
   var args = ArgTypes.queryArgs(arguments);
   var e = new Error();  // initialize error object before we do any async stuff to get a useful stacktrace
 
+  //check if we just should return the sql-string, not execute it
+  if(args.options.toString === true) return args.next(null, args.sql);
+
   //check to see if the params are an array, which they need to be
   //for the pg module
   if(_.isObject(args.params)){


### PR DESCRIPTION
Added "toString"-option, allows Massive to return generated sql without executing it:
```
var sql = db.users.save({ firstName:'Peter' }, {toString:true})
console.log(sql) // 'insert into...'
```
Why?

- Allows massive to be used as query builder.
- Simple debugging, easily view generated queries.
- Makes it possible to create quick transactions: 
```
db.query([
    'BEGIN',
    db.users.save({ name: 'Peter' }, {toString:true}),
    db.users.save({ name: 'OtherGuy' }, {toString:true}),
    'COMMIT'
  ].join(';'), function(...)
})
```