### PR TITLE
add support for whitelisting functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ var Massive = function(args){
   // will be a "falsy" value, and functions will be included...
   this.excludeFunctions = args.excludeFunctions;
   this.functionBlacklist = this.getTableFilter(args.functionBlacklist);
+  this.functionWhitelist = this.getTableFilter(args.functionWhitelist);
 };
 
 Massive.prototype.getSchemaFilter = function(allowedSchemas) {
@@ -281,7 +282,7 @@ var walkSqlFiles = function(rootObject, rootDir) {
 Massive.prototype.loadFunctions = function(next) {
   if (!this.excludeFunctions) {
     var functionSql = __dirname + "/lib/scripts/functions.sql";
-    var parameters = [this.functionBlacklist];
+    var parameters = [this.functionBlacklist, this.functionWhitelist];
 
     this.executeSqlFile({file : functionSql, params : parameters}, function (err,functions) {
       if (err) {

--- a/lib/scripts/functions.sql
+++ b/lib/scripts/functions.sql
@@ -1,5 +1,5 @@
--- Exclude functions with a name matching the string pattern passed in (i.e. "pg_%")
--- exclusion is schema - aspecific, no schema assumes 'public'
+-- Include and/or exclude functions with a name matching the string pattern passed in (i.e. "pg_%")
+-- inclusion/exclusion is schema - aspecific, no schema assumes 'public'
 select distinct
     n.nspname as "schema",
     p.proname as "name",
@@ -11,5 +11,9 @@ where n.nspname not in ('pg_catalog','information_schema')
   and (case -- blacklist functions using LIKE by fully-qualified name (no schema assumes public):
             when $1 = '' then 1=1
             else replace((n.nspname || '.'|| p.proname), 'public.', '')  not like all(string_to_array(replace($1, ' ', ''), ','))
+       end)
+  and (case -- whitelist functions using LIKE by fully-qualified name (no schema assumes public):
+            when $2 = '' then 1=1
+            else replace((n.nspname || '.'|| p.proname), 'public.', '') like any(string_to_array(replace($2, ' ', ''), ','))
        end)
 order by n.nspname, p.proname;

--- a/test/load_filter_spec.js
+++ b/test/load_filter_spec.js
@@ -278,8 +278,8 @@ describe('On load with Function Exclusion (these tests may run slow - loads db e
   });
 });
 
-describe('On load with Function Blacklist (these tests may run slow - loads db each test!!)', function () {
-  it('loads all functions when no blacklist argument is provided', function (done) {
+describe('On load with Function Blacklist and/or Whitelist (these tests may run slow - loads db each test!!)', function () {
+  it('loads all functions when no blacklist and no whitelist argument is provided', function (done) {
     massive.connect({connectionString: helpers.connectionString}, function (err, db) {
       assert.ifError(err);
       assert(db.AllMyProducts && db.all_products && db.myschema.AllMyAlbums && db.myschema.all_albums && db.myschema.artist_by_name);
@@ -300,17 +300,45 @@ describe('On load with Function Blacklist (these tests may run slow - loads db e
       done();
     });
   });
-  it('excludes functions with name and schema matching multiiple blacklist patterns as a comma-delimited string argument', function (done) {
+  it('excludes functions with name and schema matching multiple blacklist patterns as a comma-delimited string argument', function (done) {
     massive.connect({connectionString: helpers.connectionString, functionBlacklist: "myschema.artist_%, all_%"}, function (err, db) {
       assert.ifError(err);
       assert(!db.myschema.artist_by_name && !db.all_products && db.myschema.all_albums && db.AllMyProducts);
       done();
     });
   });
-  it('excludes functions with name and schema matching multiiple blacklist patterns as a string array argument', function (done) {
+  it('excludes functions with name and schema matching multiple blacklist patterns as a string array argument', function (done) {
     massive.connect({connectionString: helpers.connectionString, functionBlacklist: ["myschema.artist_%", "all_%"]}, function (err, db) {
       assert.ifError(err);
       assert(!db.myschema.artist_by_name && !db.all_products && db.myschema.all_albums && db.AllMyProducts);
+      done();
+    });
+  });
+  it('includes functions with name and schema matching whitelist pattern as a string argument', function (done) {
+    massive.connect({connectionString: helpers.connectionString, functionWhitelist: "myschema.all_%"}, function (err, db) {
+      assert.ifError(err);
+      assert(db.myschema.all_albums && !db.myschema.AllMyAlbums && !db.myschema.artist_by_name && !db.all_products);
+      done();
+    });
+  });
+  it('includes functions with name and schema matching multiple whitelist patterns as a comma-delimited string argument', function (done) {
+    massive.connect({connectionString: helpers.connectionString, functionWhitelist: "myschema.artist_%, all_%"}, function (err, db) {
+      assert.ifError(err);
+      assert(db.myschema.artist_by_name && db.all_products && !db.myschema.all_albums && !db.AllMyProducts);
+      done();
+    });
+  });
+  it('includes functions with name and schema matching multiple whitelist patterns as a string array argument', function (done) {
+    massive.connect({connectionString: helpers.connectionString, functionWhitelist: ["myschema.artist_%", "all_%"]}, function (err, db) {
+      assert.ifError(err);
+      assert(db.myschema.artist_by_name && db.all_products && !db.myschema.all_albums && !db.AllMyProducts);
+      done();
+    });
+  });
+  it('both includes (whitelists) and excludes (blacklists) functions as a string arguments', function (done) {
+    massive.connect({connectionString: helpers.connectionString, functionWhitelist: "myschema.a%", functionBlacklist: "myschema.%by_name"}, function (err, db) {
+      assert.ifError(err);
+      assert(db.myschema.all_albums && !db.myschema.artist_by_name && !db.myschema.AllMyAlbums && !db.all_products);
       done();
     });
   });


### PR DESCRIPTION
It's really tedious to blacklist functions, especially if there are a lot of them - the list is growing very fast and has to be updated frequently.
It's much easier to move all functions to a separate schema (eg. "api") and whitelist all functions in this schema:
`massive.connectSync({connectionString : connectionString, functionWhitelist: 'api.%'})`

This PR adds whitelist functionality along with blacklist, so you can use both for fine grained filtering of functions.