### PR TITLE
Updated node-postgres dependency to v4.5.5 for a Node 6 issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "commander": "^2.6.0",
     "deasync": "^0.1.1",
     "glob": "^4.4.1",
-    "pg": "^4.3.0",
+    "pg": "^4.5.5",
     "pg-query-stream": "^0.7.0",
     "strip-bom": "^2.0.0",
     "underscore": "^1.8.2"


### PR DESCRIPTION
Fixes the Node 6.0.0 issue (https://github.com/brianc/node-postgres/issues/1000) which I was experiencing with a Node v6 test app on Heroku.

All tests still pass with this latest version of pg