### PR TITLE
allow multiple arguments to be passed in naked

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -48,7 +48,7 @@ massive.connect({
 ```
 
 ## Parameters
-Many, if not most, functions will expect some sort of input. If the function takes only one parameter, it may be passed in raw:
+Many, if not most, functions will expect some sort of input.
 
 ```js
 var massive = require("massive");
@@ -61,7 +61,20 @@ massive.connect({
 });
 ```
 
-If it takes multiple parameters, they must be wrapped in an Array:
+And you can do that with multiple inputs as well:
+
+```js
+var massive = require("massive");
+
+massive.connect({
+  connectionString: "postgres://localhost/massive"}, function(err, db) {
+  db.top_x_products_by_country(5, 'US', function(err, products) {
+    //products is a results array
+  });
+});
+```
+
+You may also pass in multiple arguments as a single Array, but you do not have to:
 
 ```js
 var massive = require("massive");
@@ -73,3 +86,6 @@ massive.connect({
   });
 });
 ```
+
+The inputs must be scalars.  You may not pass in objects or arrays as arguments per-se.  You are allowed to group all inputs into an array and pass them in as that (as demonstrated in the last example), should you like to do so.
+

--- a/lib/executable.js
+++ b/lib/executable.js
@@ -14,27 +14,39 @@ var Executable = function(args) {
 
 util.inherits(Executable, Entity);
 
-Executable.prototype.invoke = function(params, opts, next) {
-  if (_.isFunction(params)) {       // invoked as db.function(callback)
-    next = params;
-    params = [];
-    opts = {};
-  } else if (_.isFunction(opts)) {  // invoked as db.function(something, callback)
-    next = opts;
 
-    // figure out if we were given params or opts as the first argument
-    // lucky for us it's mutually exclusive: opts can only be an object, params can be a primitive or an array
-    if (_.isObject(params) && !_.isArray(params)) { // it's an options object, we have no params
-      opts = params;
-      params = [];
-    } else {                                        // it's a parameter primitive or array, we have no opts
-      opts = {};
-    }
+// invoke with:
+//   db.function(opts, callback)
+//   db.function([arg1, arg2, ...], opts, callback)
+//   db.function(arg1, arg2, ..., opts, callback)
+//
+//  where opts is optional and can be left out
+//        args must be scalar types (no arrays or objects)
+
+Executable.prototype.invoke = function() {
+
+  var args = Array.prototype.slice.call(arguments);
+  var next = args.pop();
+  var opts = {};
+  var params = [];
+
+  if (!_.isFunction(next)) {
+    throw "Function or Script Execution expects a next function as the last argument";
   }
 
-  if (!_.isArray(params)) {
-    params = [params];
+  if (!_.isArray(_.last(args)) && _.isObject(_.last(args))) {
+    opts = args.pop();
   }
+
+  if (_.isArray(args[0])) {          // backwards compatible -- db.function([...], ?opts, callback)
+    params = args[0];
+  } else {
+    params = args;
+  }
+
+  // console.log("invoke next: ", next);
+  // console.log("invoke opts: ", opts);
+  // console.log("invoke params: ", params);
 
   if (opts.stream) {
     this.db.stream(this.sql, params, null, next);

--- a/test/db/multiple_args.sql
+++ b/test/db/multiple_args.sql
@@ -1,0 +1,11 @@
+select 
+        cast ($1 as int) as a1,
+        cast ($2 as int) as a2,
+        cast ($3 as int) as a3,
+        cast ($4 as int) as a4,
+        cast ($5 as int) as a5,
+        cast ($6 as int) as a6;
+
+
+
+

--- a/test/function_spec.js
+++ b/test/function_spec.js
@@ -1,11 +1,56 @@
 var assert = require("assert");
 var helpers = require("./helpers");
+var _ = require("underscore");
 var db;
 
 describe('Functions', function () {
   before(function(done){
     helpers.resetDb(function(err,res){
       db = res;
+      done();
+    });
+  });
+  it('executes multiple args without passing as array', function (done) {
+      db.multiple_args(1, 2, 3, 4, 5, 6, function(err,res){
+        assert.ifError(err);
+        assert(res.length === 1);
+        var record = res[0];
+        _.each([1, 2, 3, 4, 5, 6], function (idx) {
+          assert(record["a" + idx] === idx);
+      });
+      done();
+    });
+  });
+  it('executes multiple args with passing as array', function (done) {
+    db.multiple_args([1, 2, 3, 4, 5, 6], function(err,res){
+      assert.ifError(err);
+      assert(res.length === 1);
+      var record = res[0];
+      _.each([1, 2, 3, 4, 5, 6], function (idx) {
+        assert(record["a" + idx] === idx);
+      });
+      done();
+    });
+  });
+  it('executes multiple args without passing as an array and using options', function (done) {
+    db.multiple_args(1, 2, 3, 4, 5, 6, { this_is_ignored: true }, function(err,res){
+      assert.ifError(err);
+      assert(res.length === 1);
+      var record = res[0];
+      _.each([1, 2, 3, 4, 5, 6], function (idx) {
+        assert(record["a" + idx] === idx);
+      });
+      done();
+    });
+  });
+  it('executes multiple args with passing as an array and using options', function (done) {
+    db.multiple_args([1, 2, 3, 4, 5, 6], { this_is_ignored: true }, function(err,res){
+      assert.ifError(err);
+      assert(res.length === 1);
+      var record = res[0];
+      _.each([1, 2, 3, 4, 5, 6], function (idx) {
+        assert(record["a" + idx] === idx);
+      });
       done();
     });
   });

--- a/test/loader_spec.js
+++ b/test/loader_spec.js
@@ -23,9 +23,9 @@ describe('On spin up', function () {
     assert.equal(db.tables.length, 10);
   });
 
-  // including one nested in a deeper folder... total of 4 now.
-  it('loads up 7 queries', function () {
-    assert.equal(db.queryFiles.length, 7);
+  // including one nested in a deeper folder... total of 8 now.
+  it('loads up 8 queries', function () {
+    assert.equal(db.queryFiles.length, 8);
   });
   it('loads up functions', function () {
     // newer versions of postgres include more than 20 functions
@@ -57,9 +57,9 @@ describe('Synchronous Load', function () {
     assert.equal(syncLoaded.tables.length, 10);
   });
 
-  // including one nested in a deeper folder... total of 4 now.
-  it('loads up 7 queries', function () {
-    assert.equal(syncLoaded.queryFiles.length, 7);
+  // including one nested in a deeper folder... total of 8 now.
+  it('loads up 8 queries', function () {
+    assert.equal(syncLoaded.queryFiles.length, 8);
   });
   it('loads up functions', function () {
     // newer versions of postgres include more than 20 functions


### PR DESCRIPTION
I was calling a SQL function, and started with a single argument, then went to add a second argument and it stopped working.  I thought it was a bug in massive-js but after some investigation it found that it really wasn't.  It was even documented that way.

Anyhow, I'm not sure why it was implemented that way:  naked for single value, array for more than one.  I added the ability to allow multiple arguments to be passed in without it needing to be an array, but also made sure that if they ARE passed in as an array that it doesn't break.

See test code.

I'm hoping you'll like this change OK.  I think it's cleaner in that it won't surprise the user -- this way the usage has the same signature, regardless if it's 0, 1, or N arguments that you're passing in.

I hope I'm not missing something, and please excuse me if I did...