### PR TITLE
Example was not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ The API is as close to Massive 1.0 as we could make it - but there's no need for
 //connect massive, get db instance
 
 //straight up SQL
-db.run("select * from products where id=$1", 1, function(err,product){
+db.run("select * from products where id=$1", [1], function(err,product){
   //product 1
 });
 


### PR DESCRIPTION
If you pass 1 instead of [1] it says: Error: You need to wrap your parameter into an array.