### PR TITLE
Added possibility to pass conditions to searchDoc

### DIFF
--- a/lib/arg_types.js
+++ b/lib/arg_types.js
@@ -77,6 +77,7 @@ exports.forArgs = function(args) {
   return Args([
     {conditions: Args.OBJECT},
     {generator: Args.STRING | Args.Optional, _default: 'predicate'},
-    {placeholderOffset: Args.INT | Args.Optional, _default: 0}
+    {placeholderOffset: Args.INT | Args.Optional, _default: 0},
+    {prefix: Args.STRING | Args.Optional, _default: ' \nWHERE '}
   ], args);
 };

--- a/lib/document_table.js
+++ b/lib/document_table.js
@@ -10,6 +10,7 @@ var DA = require("deasync");
 exports.searchDoc = function(){
   var args = ArgTypes.searchArgs(arguments, this);
   assert(args.fields.keys && args.fields.term, "Need the keys to use and the term string");
+  var params = [args.fields.term];
   //yuck full repetition here... fix me...
   if(!_.isArray(args.fields.keys)){
     args.fields.keys = [args.fields.keys];
@@ -24,11 +25,17 @@ exports.searchDoc = function(){
     });
     tsv= util.format("concat(%s)", formattedKeys.join(", ' ',"));
   }
-  
-  var sql = "select * from " + this.fullname + " where " + util.format("to_tsvector(%s)", tsv);
-  sql+= " @@ to_tsquery($1)" + args.options.queryOptions();
 
-  this.executeDocQuery(sql, [args.fields.term], args.options, args.next);
+  var whereString;
+  if(args.fields.where){
+    var where = this.getWhereForDoc(args.fields.where, 1, ' AND ');
+    whereString = where.where;
+    params = params.concat(where.params);
+  }
+  
+  var sql = "select * from " + this.fullname + " where " + util.format("to_tsvector(%s)", tsv); 
+  sql+= " @@ to_tsquery($1)" + (whereString || '') + args.options.queryOptions();
+  this.executeDocQuery(sql, params, args.options, args.next);
 };
 exports.searchDocSync = DA(this.serchDoc);
 
@@ -76,7 +83,7 @@ exports.findDoc = function() {
 };
 exports.findDocSync = DA(this.findDoc);
 
-this.getWhereForDoc = function(conditions) {
+this.getWhereForDoc = function(conditions, offset, prefix) {
   var where = {pkQuery: false};
   if(_.isFunction(conditions) || conditions == "*") {
     // no criteria provided - treat like select *
@@ -99,17 +106,17 @@ this.getWhereForDoc = function(conditions) {
       if (property == this.primaryKeyName()) {
         // this is a query against the PK...we can use the
         // plain old table "where" builder:
-        where = Where.forTable(conditions);
-
+        where = Where.forTable(conditions, 'predicate', offset, prefix);
+  
         // only a true pk query if testing equality
         if (operator === null || operator === "=") {
           where.pkQuery = true;
         }
       } else {
-        where = Where.forTable(conditions, 'docPredicate');
+        where = Where.forTable(conditions, 'docPredicate', offset, prefix);
       }
     } else {
-      where = Where.forTable(conditions, 'docPredicate');
+      where = Where.forTable(conditions, 'docPredicate', offset, prefix);
     }
   }
 

--- a/lib/where.js
+++ b/lib/where.js
@@ -231,7 +231,7 @@ exports.forTable = function () {
   }, args.conditions, args.generator);
 
   return {
-    where: ' \nWHERE ' + result.predicates.join(' \nAND '),
+    where: args.prefix + result.predicates.join(' \nAND '),
     params: result.params
   };
 };

--- a/test/document_query_spec.js
+++ b/test/document_query_spec.js
@@ -259,5 +259,17 @@ describe('Document queries', function () {
         });
       });
     });
+
+    it('returns right elements if filter is specified', function (done) {
+      db.docs.searchDoc({
+        keys : ["title"],
+        term : "Document",
+        where: {'price': 22.00}
+      }, function(err, docs){
+        assert.ifError(err);
+        assert.equal(docs.length, 1);
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
This is in order to do a full text search in addition to filtering on e.g. 
`db.docs.searchDoc({
   keys : ["title"],
   term : "Document"
}, {order: 'id desc'}, {is_good: true}, function(err, res){
....
})`

The code is not beautiful, and i'm guessing there is a better way to reuse `getWhereForDoc` so that we don't have to do all that replacing, and I would be happy to implement that, if anyone could point me in the right direction.