### PR TITLE
Omtting functions as column names when updating (_.omit)

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -60,7 +60,9 @@ Table.prototype.update = function(conditions, fields, next) {
 
     conditions[pkName] = fields[pkName];
 
-    fields = _.omit(fields, pkName);
+    fields = _.omit(fields, function(value, key, object) {
+      return _.isFunction(object[key]) || key === pkName;
+    });
 
     options.single = true;
   }


### PR DESCRIPTION
When updating a object, columns names are retrieved with _.omit
Underscore omit also returns functions names from object ( see https://gist.github.com/lfreneda/1100ecfedf7a2bec7cc527a0b0bde69c )
I'm omitting not only pk column/property but also functions/methods

based on issue 206 ( https://github.com/robconery/massive-js/issues/260 )