### PR TITLE
Function return types

### DIFF
--- a/docs/connecting.md
+++ b/docs/connecting.md
@@ -7,7 +7,8 @@ massive.connect({
   connectionString: 'postgres://postgres@localhost/massive',
   defaults: {
     poolSize: 20
-  }
+  },
+  enhancedFunctions: true
 }, function (err, db) {
   // db contains your tables, views, and functions
 })
@@ -21,3 +22,7 @@ the underlying node-postgres driver to set options such as `poolSize` or
 `parseInt8`. For more complete documentation of available driver defaults, see
 the [node-postgres](https://github.com/brianc/node-postgres/wiki/pg#pgdefaults)
 documentation.
+
+`enhancedFunctions` is an experimental setting that allows functions to return
+a value matching their return type rather than a set of rows, see
+[Function Invocation](functions.md#function-invocation).

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -47,6 +47,39 @@ massive.connect({
 });
 ```
 
+### Experimental: Enhanced Functions
+
+Massive can interpret the return types of functions, however this breaks backwards compatibility and thus must be opted into with setting `enhancedFunctions: true`.
+
+For example, if you have this [getRandomNumber function](https://xkcd.com/221/):
+
+```sql
+create function myschema."getRandomNumber"()
+returns integer as $$
+select 4; -- chosen by fair dice roll.
+          -- guaranteed to be random.
+$$ language sql;
+```
+
+Without `enhancedFunctions` you'd get the same results as a regular table fetch - a set of rows: `[{"getRandomNumber": 4}]`.
+
+With `enhancedFunctions: true`, you'd get simply the result of the function: `4`.
+
+```js
+var massive = require("massive");
+
+massive.connect({
+  connectionString: "postgres://localhost/massive",
+  enhancedFunctions: true // Enable return type honoring
+}, function(err, db) {
+  db.getRandomNumber(function(err, randomNumber) {
+    //randomNumber is the integer 4
+  });
+});
+```
+
+This also works for text, arrays, JSON, text domains and some other types. If it doesn't work for your use case, please raise an issue (or a PR!); we're aware of some restrictions due to [how the pg module currently handles types](https://github.com/brianc/node-postgres/issues/986).
+
 ## Parameters
 Many, if not most, functions will expect some sort of input.
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ var self;
 
 var Massive = function(args) {
   this.scriptsDir = args.scripts || process.cwd() + "/db";
+  this.interpretFunctionReturnTypes = args.interpretFunctionReturnTypes || false;
 
   var runner = new Runner(args.connectionString, args.defaults);
   _.extend(this, runner);
@@ -441,8 +442,8 @@ Massive.prototype.loadFunctions = function(next) {
             schema: schema,
             name : fn.name,
             db : self,
-            singleRow: fn.return_single_row,
-            singleValue: fn.return_single_value
+            singleRow: self.interpretFunctionReturnTypes && fn.return_single_row,
+            singleValue: self.interpretFunctionReturnTypes && fn.return_single_value
           });
 
           MapToNamespace(_exec, "functions");

--- a/index.js
+++ b/index.js
@@ -440,7 +440,9 @@ Massive.prototype.loadFunctions = function(next) {
             sql: sql,
             schema: schema,
             name : fn.name,
-            db : self
+            db : self,
+            singleRow: fn.return_single_row,
+            singleValue: fn.return_single_value
           });
 
           MapToNamespace(_exec, "functions");

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var self;
 
 var Massive = function(args) {
   this.scriptsDir = args.scripts || process.cwd() + "/db";
-  this.interpretFunctionReturnTypes = args.interpretFunctionReturnTypes || false;
+  this.enhancedFunctions = args.enhancedFunctions || false;
 
   var runner = new Runner(args.connectionString, args.defaults);
   _.extend(this, runner);
@@ -442,8 +442,8 @@ Massive.prototype.loadFunctions = function(next) {
             schema: schema,
             name : fn.name,
             db : self,
-            singleRow: self.interpretFunctionReturnTypes && fn.return_single_row,
-            singleValue: self.interpretFunctionReturnTypes && fn.return_single_value
+            singleRow: self.enhancedFunctions && fn.return_single_row,
+            singleValue: self.enhancedFunctions && fn.return_single_value
           });
 
           MapToNamespace(_exec, "functions");

--- a/lib/executable.js
+++ b/lib/executable.js
@@ -12,10 +12,6 @@ var Executable = function(args) {
   this.filePath = args.filePath;
   this.singleRow = args.singleRow;
   this.singleValue = args.singleValue;
-
-  if (this.singleValue && !this.singleRow) {
-    throw new Error("We do not yet support singleValue unless singleRow is set.");
-  }
 };
 
 util.inherits(Executable, Entity);
@@ -58,6 +54,17 @@ Executable.prototype.invoke = function() {
   // console.log("invoke opts: ", opts);
   // console.log("invoke params: ", params);
 
+  function _processSingleValue(data) {
+    if (singleValue && !_.isNull(data)) {
+      var keys = Object.keys(data);
+      if (keys.length != 1) {
+        throw new Error("Was expecting just one value");
+      }
+      data = data[keys[0]];
+    }
+    return data;
+  }
+
   if (opts.stream) {
     this.db.stream(this.sql, params, null, next);
   } else {
@@ -65,18 +72,22 @@ Executable.prototype.invoke = function() {
     this.db.query(this.sql, params, null, function (err, rawData) {
       var data = rawData;
       if (err) return next(err);
-      if (singleRow) {
-        if (!Array.isArray(data)) {
-          return next(new Error("Was expecting an array"));
+      try {
+        if (singleRow) {
+          if (!Array.isArray(data)) {
+            return next(new Error("Was expecting an array"));
+          }
+          data = data[0] || null;
+          if (singleValue) {
+            data = _processSingleValue(data);
+          }
+        } else {
+          if (singleValue) {
+            data = data.map(_processSingleValue);
+          }
         }
-        data = data[0] || null;
-      }
-      if (singleValue && !_.isNull(data)) {
-        var keys = Object.keys(data);
-        if (keys.length != 1) {
-          return next(new Error("Was expecting just one value"));
-        }
-        data = data[keys[0]];
+      } catch (e) {
+        err = e;
       }
       return next(err, data);
     });

--- a/lib/executable.js
+++ b/lib/executable.js
@@ -10,6 +10,12 @@ var Executable = function(args) {
 
   this.sql = args.sql;
   this.filePath = args.filePath;
+  this.singleRow = args.singleRow;
+  this.singleValue = args.singleValue;
+
+  if (this.singleValue && !this.singleRow) {
+    throw new Error("We do not yet support singleValue unless singleRow is set.");
+  }
 };
 
 util.inherits(Executable, Entity);
@@ -34,6 +40,10 @@ Executable.prototype.invoke = function() {
     throw "Function or Script Execution expects a next function as the last argument";
   }
 
+  if (opts.stream && (this.singleRow || this.singleValue)) {
+    throw new Error("Streaming singleRow/singleValue is not supported");
+  }
+
   if (!_.isArray(_.last(args)) && _.isObject(_.last(args))) {
     opts = args.pop();
   }
@@ -51,7 +61,25 @@ Executable.prototype.invoke = function() {
   if (opts.stream) {
     this.db.stream(this.sql, params, null, next);
   } else {
-    this.db.query(this.sql, params, null, next);
+    var singleRow = this.singleRow, singleValue = this.singleValue;
+    this.db.query(this.sql, params, null, function (err, rawData) {
+      var data = rawData;
+      if (err) return next(err);
+      if (singleRow) {
+        if (!Array.isArray(data)) {
+          throw new Error("Was expecting an array");
+        }
+        data = data[0] || null;
+      }
+      if (singleValue && !_.isNull(data)) {
+        var keys = Object.keys(data);
+        if (keys.length != 1) {
+          throw new Error("Was expecting just one value");
+        }
+        data = data[keys[0]];
+      }
+      return next(err, data);
+    });
   }
 };
 

--- a/lib/executable.js
+++ b/lib/executable.js
@@ -1,6 +1,43 @@
 var _ = require("underscore")._;
 var util = require('util');
 var Entity = require('./entity');
+var Transform = require('stream').Transform;
+var inherits = require('util').inherits;
+
+// Takes a single-key object like {"foo": 27} and just returns the 27 part
+function _processSingleValue(data) {
+  if (!_.isNull(data)) {
+    var keys = Object.keys(data);
+    if (keys.length != 1) {
+      throw new Error("Was expecting just one value");
+    }
+    data = data[keys[0]];
+  }
+  return data;
+}
+
+function SingleValueStream(options) {
+  if (!(this instanceof SingleValueStream)) {
+    return new SingleValueStream(options);
+  }
+  if (!options) {
+    options = {};
+  }
+  options.objectMode = true;
+  Transform.call(this, options);
+}
+
+inherits(SingleValueStream, Transform);
+
+SingleValueStream.prototype._transform = function _transform(obj, encoding, callback) {
+  try {
+    obj = _processSingleValue(obj);
+  } catch(err) {
+    return callback(err);
+  }
+  this.push(obj);
+  callback();
+};
 
 /**
  * An executable function or script.
@@ -36,10 +73,6 @@ Executable.prototype.invoke = function() {
     throw "Function or Script Execution expects a next function as the last argument";
   }
 
-  if (opts.stream && (this.singleRow || this.singleValue)) {
-    throw new Error("Streaming singleRow/singleValue is not supported");
-  }
-
   if (!_.isArray(_.last(args)) && _.isObject(_.last(args))) {
     opts = args.pop();
   }
@@ -54,21 +87,20 @@ Executable.prototype.invoke = function() {
   // console.log("invoke opts: ", opts);
   // console.log("invoke params: ", params);
 
-  function _processSingleValue(data) {
-    if (singleValue && !_.isNull(data)) {
-      var keys = Object.keys(data);
-      if (keys.length != 1) {
-        throw new Error("Was expecting just one value");
-      }
-      data = data[keys[0]];
-    }
-    return data;
-  }
+  var singleRow = this.singleRow && !opts.stream;
+  var singleValue = this.singleValue;
 
   if (opts.stream) {
-    this.db.stream(this.sql, params, null, next);
+    this.db.stream(this.sql, params, null, function (err, stream) {
+      if (err) return next(err);
+      if (singleValue) {
+        var singleValueTransform = SingleValueStream();
+        return next(null, stream.pipe(singleValueTransform));
+      } else {
+        return next(null, stream);
+      }
+    });
   } else {
-    var singleRow = this.singleRow, singleValue = this.singleValue;
     this.db.query(this.sql, params, null, function (err, rawData) {
       var data = rawData;
       if (err) return next(err);

--- a/lib/executable.js
+++ b/lib/executable.js
@@ -67,14 +67,14 @@ Executable.prototype.invoke = function() {
       if (err) return next(err);
       if (singleRow) {
         if (!Array.isArray(data)) {
-          throw new Error("Was expecting an array");
+          return next(new Error("Was expecting an array"));
         }
         data = data[0] || null;
       }
       if (singleValue && !_.isNull(data)) {
         var keys = Object.keys(data);
         if (keys.length != 1) {
-          throw new Error("Was expecting just one value");
+          return next(new Error("Was expecting just one value"));
         }
         data = data[keys[0]];
       }

--- a/lib/scripts/functions.sql
+++ b/lib/scripts/functions.sql
@@ -3,7 +3,7 @@
 select distinct
     n.nspname as "schema",
     (not p.proretset) as "return_single_row",
-    (t.typtype in ('b', 'e', 'r')) as "return_single_value",
+    (t.typtype in ('b', 'd', 'e', 'r')) as "return_single_value",
     p.proname as "name",
     p.pronargs as param_count
 from pg_proc p

--- a/lib/scripts/functions.sql
+++ b/lib/scripts/functions.sql
@@ -3,7 +3,7 @@
 select distinct
     n.nspname as "schema",
     (not p.proretset) as "return_single_row",
-    (t.typtype = 'b') as "return_single_value",
+    (t.typtype in ('b', 'e', 'r')) as "return_single_value",
     p.proname as "name",
     p.pronargs as param_count
 from pg_proc p

--- a/lib/scripts/functions.sql
+++ b/lib/scripts/functions.sql
@@ -2,10 +2,13 @@
 -- inclusion/exclusion is schema - aspecific, no schema assumes 'public'
 select distinct
     n.nspname as "schema",
+    (not p.proretset) as "return_single_row",
+    (t.typtype = 'b') as "return_single_value",
     p.proname as "name",
     p.pronargs as param_count
 from pg_proc p
      inner join pg_namespace n on (p.pronamespace = n.oid)
+     inner join pg_type t on (p.prorettype = t.oid)
 where n.nspname not in ('pg_catalog','information_schema')
   and n.nspname NOT LIKE 'pgp%'
   and (case -- blacklist functions using LIKE by fully-qualified name (no schema assumes public):

--- a/test/db/schema.sql
+++ b/test/db/schema.sql
@@ -228,3 +228,11 @@ $$ language sql;
 -- , (case when random() > 0.5 then 'heads'::coin_toss else 'tails'::coin_toss end)
 -- ];
 -- $$ language sql;
+
+drop function if exists example_email();
+drop domain if exists email_address;
+create domain email_address as text check(value similar to '[^@]+@[^@]+.[^@]+');
+
+create function example_email() returns email_address as $$
+select 'example@example.com'::email_address;
+$$ language sql;

--- a/test/db/schema.sql
+++ b/test/db/schema.sql
@@ -82,6 +82,8 @@ create materialized view mv_orders as select * from orders;
 drop table if exists myschema.artists cascade;
 drop table if exists myschema.albums cascade; -- drops functions too
 drop table if exists myschema.docs;
+drop function if exists myschema."JsonHelloWorld"();
+drop function if exists myschema."getRandomNumber"();
 
 -- just in case:
 drop table if exists myschema.doggies;
@@ -176,5 +178,30 @@ returns setof myschema.albums
 as
 $$
 select * from myschema.albums;
+$$
+language sql;
+
+create or replace function myschema."RandomAlbum"()
+returns myschema.albums
+as
+$$
+select * from myschema.albums order by random() limit 1;
+$$
+language sql;
+
+create or replace function myschema."getRandomNumber"()
+returns integer
+as
+$$
+select 4; -- chosen by fair dice roll.
+          -- guaranteed to be random.
+$$
+language sql;
+
+create or replace function myschema."JsonHelloWorld"()
+returns json
+as
+$$
+select '{"hello": "world"}'::json;
 $$
 language sql;

--- a/test/db/schema.sql
+++ b/test/db/schema.sql
@@ -205,3 +205,26 @@ $$
 select '{"hello": "world"}'::json;
 $$
 language sql;
+
+create or replace function yesses() returns text[] as $$
+select array['yes', 'yes', 'yes', 'yes'];
+$$ language sql;
+
+drop function if exists coin_toss();
+drop function if exists coin_tosses();
+drop type if exists coin_toss;
+create type coin_toss as enum ('heads', 'tails');
+
+create function coin_toss() returns coin_toss as $$
+select (case when random() > 0.5 then 'heads'::coin_toss else 'tails'::coin_toss end);
+$$ language sql;
+
+-- `pg` module doesn't support arrays of custom types yet
+-- see: https://github.com/brianc/node-postgres/issues/986
+-- create function coin_tosses() returns coin_toss[] as $$
+-- select array[
+--   (case when random() > 0.5 then 'heads'::coin_toss else 'tails'::coin_toss end)
+-- , (case when random() > 0.5 then 'heads'::coin_toss else 'tails'::coin_toss end)
+-- , (case when random() > 0.5 then 'heads'::coin_toss else 'tails'::coin_toss end)
+-- ];
+-- $$ language sql;

--- a/test/db/schema.sql
+++ b/test/db/schema.sql
@@ -1,4 +1,5 @@
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS citext;
 
 drop materialized view if exists mv_orders;
 drop table if exists "Users";

--- a/test/function_spec.js
+++ b/test/function_spec.js
@@ -142,5 +142,37 @@ describe('Functions', function () {
         done();
       });
     });
+    it("executes function yesses and returns array of 'yes'", function (done) {
+      db.yesses(function(err,res) {
+        assert.ifError(err);
+        assert(Array.isArray(res), "Expected array");
+        res.forEach(function(el) {
+          assert.equal(el, 'yes');
+        });
+        done();
+      });
+    });
+    it("executes function coin_toss and returns 'heads' or 'tails'", function (done) {
+      db.coin_toss(function(err,res) {
+        assert.ifError(err);
+        assert(['heads', 'tails'].indexOf(res) >= 0, "'" + res + "' must be heads or tails");
+        done();
+      });
+    });
+    /*
+    // `pg` module doesn't support arrays of custom types yet
+    // see: https://github.com/brianc/node-postgres/issues/986
+    it("executes function coin_tosses and returns array of 'heads' or 'tails'", function (done) {
+      db.coin_tosses(function(err,res) {
+        assert.ifError(err);
+        console.dir(res);
+        assert(Array.isArray(res), "Expected array");
+        res.forEach(function(el) {
+          assert(['heads', 'tails'].indexOf(el) >= 0, "'" + el + "' must be heads or tails");
+        });
+        done();
+      });
+    });
+    */
   });
 });

--- a/test/function_spec.js
+++ b/test/function_spec.js
@@ -119,5 +119,28 @@ describe('Functions', function () {
         done();
       });
     });
+    it("executes schema-bound, camel-cased function RandomAlbum and returns the single row result", function (done) {
+      db.myschema.RandomAlbum(function(err,res) {
+        assert.ifError(err);
+        assert(_.isObject(res));
+        assert.deepEqual(Object.keys(res), ["id", "title", "artist_id"]);
+        done();
+      });
+    });
+    it("executes schema-bound, camel-cased function JsonHelloWorld and returns the single integer value", function (done) {
+      db.myschema.getRandomNumber(function(err,res) {
+        assert.ifError(err);
+        assert.equal(res, 4);
+        done();
+      });
+    });
+    it("executes schema-bound, camel-cased function JsonHelloWorld and returns the single JSON value", function (done) {
+      db.myschema.JsonHelloWorld(function(err,res) {
+        assert.ifError(err);
+        assert(_.isObject(res));
+        assert.deepEqual(res, {hello: "world"});
+        done();
+      });
+    });
   });
 });

--- a/test/function_spec.js
+++ b/test/function_spec.js
@@ -174,5 +174,12 @@ describe('Functions', function () {
       });
     });
     */
+    it("executes function example_email and returns 'example@example.com'::email_address", function (done) {
+      db.example_email(function(err,res) {
+        assert.ifError(err);
+        assert.equal(res, 'example@example.com');
+        done();
+      });
+    });
   });
 });

--- a/test/function_spec.js
+++ b/test/function_spec.js
@@ -181,5 +181,27 @@ describe('Functions', function () {
         done();
       });
     });
+    it("executes function regexp_matches and returns stream of matches", function (done) {
+      db.regexp_matches('aaaaaaaaaaaaaaaaaaaa', 'a', 'g', {stream: true}, function(err, stream) {
+        assert.ifError(err);
+        var result = [];
+
+        stream.on('readable', function() {
+          var res = stream.read();
+
+          if (res) {
+            result.push(res);
+          }
+        });
+
+        stream.on('end', function () {
+          assert.equal(20, result.length);
+          result.forEach(function(r) {
+            assert.equal(r, 'a');
+          });
+          done();
+        });
+      });
+    });
   });
 });

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -9,7 +9,7 @@ exports.connectionString = connectionString;
 exports.init = function(next){
   massive.connect({
     connectionString : connectionString,
-    interpretFunctionReturnTypes : true,
+    enhancedFunctions : true,
     scripts : scriptsDir}, next);
 };
 

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -9,6 +9,7 @@ exports.connectionString = connectionString;
 exports.init = function(next){
   massive.connect({
     connectionString : connectionString,
+    interpretFunctionReturnTypes : true,
     scripts : scriptsDir}, next);
 };
 


### PR DESCRIPTION
Hey again; this time I actually have a proof of concept!

I thought it would be nice to extend massive so that when you call an SQL function that returns, say, an integer; that you get an integer result. e.g. if you had this function:

```sql
create function myschema."getRandomNumber"()
returns integer as
$$
select 4; -- chosen by fair dice roll.
          -- guaranteed to be random.
$$ language sql;
```

Currently calling that in massive will give `[{getRandomNumber: 4}]`:

```js
db.myschema.getRandomNumber((err, res) => {
  assert.deepEqual(res, [{getRandomNumber: 4}]);
});
```

This PR changes that such that you instead get simply `4`:

```js
db.myschema.getRandomNumber((err, res) => {
  assert.equal(res, 4);
});
```

I've done it in as minimally invasively a way as I can achieve; but that means that anyone relying on the old behaviour (as I had started to do in my own project) it will break for. I think we can get around this easily by just allowing people to opt-in to this feature via a configuration parameter, but I've not gone as far as to add that without receiving feedback from you first.

What are your thoughts?

---

*🎩 HT XKCD 221*