### PR TITLE
ignore dotfile or node_modules/ scripts

### DIFF
--- a/index.js
+++ b/index.js
@@ -372,6 +372,9 @@ var walkSqlFiles = function(rootObject, rootDir) {
     var ext = path.extname(item);
     var name = path.basename(item, ext);
 
+    // if dotfile, ignore
+    if (name[0] === '.') return
+
     //is this a SQL file?
     if (ext === ".sql") {
       //why yes it is! Build the abspath so we can read the file
@@ -396,7 +399,12 @@ var walkSqlFiles = function(rootObject, rootDir) {
         return _exec.invoke.apply(_exec, arguments);
       };
     } else if (ext === '') {
-      //this is a directory so shift things and move on down
+      //this is a directory
+
+      // if node_modules dir, ignore
+      if (name === 'node_modules') return
+
+      //shift things and move on down
       //set a property on our root object, then use *that*
       //as the root in the next call
       rootObject[name] = {};


### PR DESCRIPTION
hey.

i'm using the root directory of my project as my `scripts` directory, which is great because then i can make a sub-directory for each table (to include any code related to that part of my project) and `massive` includes these all quite well.

the problem is that `massive` also tries to include dotfiles and even traverse my project `node_modules`, neither of which i'm sure is ever a good idea, so here's a pull request if you agree. :smile: 