### PR TITLE
Load descendant tables

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ Massive.prototype.loadInheritsTables = function(next) {
 
         MapToNamespace(_table);
       }
-    })
+    });
 
     next(null, self);
   });
@@ -515,7 +515,7 @@ exports.connect = function(args, next) {
           next(null, db);
         });
       });
-    })
+    });
   });
 };
 

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ Massive.prototype.loadTables = function(next) {
     parameters = [this.whitelist];
   }
 
-  this.executeSqlFile({file : tableSql, params: parameters}, function(err,tables) {
+  this.executeSqlFile({file : tableSql, params: parameters}, function(err, tables) {
     if (err) { return next(err, null); }
 
     _.each(tables, function(table){
@@ -117,6 +117,33 @@ Massive.prototype.loadTables = function(next) {
     });
 
     next(null,self);
+  });
+};
+
+Massive.prototype.loadInheritsTables = function(next) {
+  var tableSql = __dirname + "/lib/scripts/tables_inherits.sql";
+  var parameters = [this.allowedSchemas, this.blacklist, this.exceptions];
+  var self = this;
+
+  this.executeSqlFile({file : tableSql, params: parameters}, function(err, tablesInherits) {
+    if (err) { return next(err, null); }
+
+    _.each(tablesInherits, function (table) {
+      // if parent table is already defined it means it has been whitelisted / validated
+      // so we safely can add the descendant to the available tables
+      if (undefined !== typeof self[table.parent]) {
+        var _table = new Table({
+          schema : table.schema,
+          name : table.child,
+          pk : self[table.parent].pk,
+          db : self
+        });
+
+        MapToNamespace(_table);
+      }
+    })
+
+    next(null, self);
   });
 };
 
@@ -474,17 +501,21 @@ exports.connect = function(args, next) {
 
     self = db;
 
-    massive.loadViews(function() {
+    massive.loadInheritsTables(function () {
       if (err) { return next(err); }
 
-      massive.loadFunctions(function(err, db) {
+      massive.loadViews(function() {
         if (err) { return next(err); }
 
-        db.loadQueries(); // synchronous
+        massive.loadFunctions(function(err, db) {
+          if (err) { return next(err); }
 
-        next(null, db);
+          db.loadQueries(); // synchronous
+
+          next(null, db);
+        });
       });
-    });
+    })
   });
 };
 

--- a/index.js
+++ b/index.js
@@ -120,15 +120,15 @@ Massive.prototype.loadTables = function(next) {
   });
 };
 
-Massive.prototype.loadInheritsTables = function(next) {
-  var tableSql = __dirname + "/lib/scripts/tables_inherits.sql";
+Massive.prototype.loadDescendantTables = function(next) {
+  var tableSql = __dirname + "/lib/scripts/descendant_tables.sql";
   var parameters = [this.allowedSchemas, this.blacklist, this.exceptions];
   var self = this;
 
-  this.executeSqlFile({file : tableSql, params: parameters}, function(err, tablesInherits) {
+  this.executeSqlFile({file : tableSql, params: parameters}, function(err, descendantTables) {
     if (err) { return next(err, null); }
 
-    _.each(tablesInherits, function (table) {
+    _.each(descendantTables, function (table) {
       // if parent table is already defined it means it has been whitelisted / validated
       // so we safely can add the descendant to the available tables
       if (undefined !== typeof self[table.parent]) {
@@ -501,7 +501,7 @@ exports.connect = function(args, next) {
 
     self = db;
 
-    massive.loadInheritsTables(function () {
+    massive.loadDescendantTables(function () {
       if (err) { return next(err); }
 
       massive.loadViews(function() {

--- a/lib/scripts/descendant_tables.sql
+++ b/lib/scripts/descendant_tables.sql
@@ -1,7 +1,6 @@
 -- REQUIRES THREE ARGUMENTS:
 -- $1, $2, $2 all must be empty string, or comma-delimited string, or array of string:
 SELECT c.relname AS child, p.relname AS parent, tc.table_schema as schema
-
 FROM pg_catalog.pg_inherits
     JOIN pg_catalog.pg_class AS c ON (inhrelid = c.oid)
     JOIN pg_catalog.pg_class AS p ON (inhparent = p.oid)

--- a/lib/scripts/tables_inherits.sql
+++ b/lib/scripts/tables_inherits.sql
@@ -1,0 +1,22 @@
+-- REQUIRES THREE ARGUMENTS:
+-- $1, $2, $2 all must be empty string, or comma-delimited string, or array of string:
+SELECT c.relname AS child, p.relname AS parent, tc.table_schema as schema
+
+FROM pg_catalog.pg_inherits
+    JOIN pg_catalog.pg_class AS c ON (inhrelid = c.oid)
+    JOIN pg_catalog.pg_class AS p ON (inhparent = p.oid)
+    JOIN information_schema.tables tc ON c.relname = tc.table_name
+WHERE
+    ((case -- allow specific schemas (none or '' assumes all):
+      when $1 ='' then 1=1
+      else tc.table_schema = any(string_to_array(replace($1, ' ', ''), ',')) end)
+    and
+    (case -- blacklist tables using LIKE by fully-qualified name (no schema assumes public):
+      when $2 = '' then 1=1
+      else replace((tc.table_schema || '.'|| tc.table_name), 'public.', '') not like all(string_to_array(replace($2, ' ', ''), ',')) end))
+    or
+    (case -- make exceptions for specific tables, with fully-qualified name or wildcard pattern (no schema assumes public).
+      when $3 = '' then 1=0
+      -- Below can use '%' as wildcard. Change 'like' to '=' to require exact names:
+      else replace((tc.table_schema || '.'|| tc.table_name), 'public.', '') like any(string_to_array(replace($3, ' ', ''), ',')) end)
+;

--- a/test/inheritance_spec.js
+++ b/test/inheritance_spec.js
@@ -34,8 +34,19 @@ describe("Table Inheritance", function () {
       });
     });
 
-    it("(currently) does not load descendant tables", function () {
-      assert.equal(db.hasOwnProperty("capitals"), false);
+    it("does load descendant tables", function () {
+      assert.equal(db.hasOwnProperty("capitals"), true);
+    });
+
+    it("descendant table rows", function (done) {
+      db.capitals.find(function (err,res) {
+        assert.ifError(err);
+        assert.equal(res.length, 4);
+
+        assert.equal(res[0].hasOwnProperty("of_state"), true);
+
+        done();
+      });
     });
   });
 


### PR DESCRIPTION
We were in need to use descendant table in Massive.

It follows the job started in https://github.com/robconery/massive-js/pull/304 and described in https://github.com/robconery/massive-js/issues/303

We have added a new `loadInheritsTables` which use an external sql file to find child and parent tables. If the parent table is already defined in Massive, we can safely add the child.
We used `pg_catalog.pg_inherits` to find these information.