### PR TITLE
Added support for arrays in setAttribute

### DIFF
--- a/lib/document_table.js
+++ b/lib/document_table.js
@@ -63,6 +63,7 @@ exports.saveDocSync = DA(this.saveDoc);
 // Only works for jsonb column type and Postgresql 9.5
 exports.setAttribute = function(id, key, val, next){
   if (typeof val === 'string') { val = JSON.stringify(val); }
+  if (Array.isArray(val)) { val = JSON.stringify(val); }
 
   var pkName = this.primaryKeyName();
   var params = ["{"+key+"}", val, id];

--- a/test/document_update_spec.js
+++ b/test/document_update_spec.js
@@ -15,6 +15,7 @@ describe('Document updates,', function(){
   // update objects set body=jsonb_set(body, '{name,last}', '', true) where id=3;
   describe("Save data and update,", function() {
     var newDoc = {};
+    var array = [1,2,3];
     before(function(done) {
       db.saveDoc("docs", {name:"Foo", score:1}, function(err, doc){
         assert.ifError(err);
@@ -35,12 +36,21 @@ describe('Document updates,', function(){
       });
     });
 
+    skipBelow95('updates the document when passed array value', function(done) {
+      db.docs.setAttribute(newDoc.id, "array", array, function(err, doc){
+        assert.ifError(err);
+        assert.deepEqual(doc.array, array);
+        done();
+      });
+    });
+
     skipBelow95('updates the document without replacing existing attributes', function(done) {
       db.docs.setAttribute(newDoc.id, "score", 99, function(err, doc){
         assert.ifError(err);
         assert.equal(doc.score, 99);
         assert.equal(doc.vaccinated, true);
         assert.equal(doc.id, newDoc.id);
+        assert.deepEqual(doc.array, array);
         done();
       });
     });
@@ -52,6 +62,7 @@ describe('Document updates,', function(){
         assert.equal(doc.vaccinated, true);
         assert.equal(doc.field, 'value');
         assert.equal(doc.id, newDoc.id);
+        assert.deepEqual(doc.array, array);
         done();
       });
     });


### PR DESCRIPTION
Calling setAttribute like so:
`db.list.setAttribute(id, "children", children, [1,2,3], function(){})`

Results in the following error in the current version
`Error: invalid input syntax for type json`

The following PR resolves this and adds tests to ensure setAttribute works with arrays.