### PR TITLE
Jsonb text array operators

### DIFF
--- a/lib/operations_map.js
+++ b/lib/operations_map.js
@@ -25,6 +25,8 @@ exports = module.exports = {
   '@>': {operator: '@>', mutator: literalizeArray},
   '<@': {operator: '<@', mutator: literalizeArray},
   '&&': {operator: '&&', mutator: literalizeArray},
+  '?|': {operator: '?|', mutator: literalizeArray},
+  '?&': {operator: '?&', mutator: literalizeArray},
   // pattern matching
   '~~': {operator: 'LIKE'},
   'like': {operator: 'LIKE'},


### PR DESCRIPTION
Could you please add two jsonb operator `?|` and `?&`? As they works only for array of strings we can use yours literalize array mutator.
These two operators used when you need to check if any or all array strings exist as top-level keys in jsonb object. See table 9-41 here:
https://www.postgresql.org/docs/9.5/static/functions-json.html