### PR TITLE
fix an error when res.count is not defined.

### DIFF
--- a/lib/queryable.js
+++ b/lib/queryable.js
@@ -75,7 +75,8 @@ Queryable.prototype.count = function() {
 
   this.db.query(sql, where.params || args.params, {single : true}, function(err, res) {
     if (err) args.next(err, null);
-    else args.next(null, res.count);
+    else if (res && res.count !== undefined) args.next(null, res.count);
+    else args.next(null, null);
   });
 };
 Queryable.prototype.countSync = DA(Queryable.prototype.count);


### PR DESCRIPTION
This adds an additional check for the existence of res and res.count.

A bug in my application lead me to encounter this error in massive. With Postgres 9.4.1, if you call __count__ with and offset option, then res.count is not defined.

$ node --version
`v7.5.0`

$ psql --version
`psql (PostgreSQL) 9.4.1`

$ cat bug.js 
```
#!/usr/bin/env node
const Massive = require('massive')
const config = require('../src/js/server/config')

const db = Massive.connectSync({ connectionString: process.env.DATABASE_URL || config.database_url })

db.saveDoc('test', { something: 1 }, (err) => {

    db.test.count({}, { offset: 1 }, (err, data) => {
        if (err) {
            console.error(err)
        }
        console.log(data)
        process.exit(0)
    })

})
```

$ ./bug.js 
```
/app/node_modules/massive/lib/queryable.js:78
    else args.next(null, res.count);
                            ^

TypeError: Cannot read property 'count' of undefined
    at Object.next (/app/node_modules/massive/lib/queryable.js:78:29)
    at Query.<anonymous> (/app/node_modules/massive/lib/runner.js:67:14)
    at Query.handleReadyForQuery (/app/node_modules/pg/lib/query.js:112:10)
    at Connection.<anonymous> (/app/node_modules/pg/lib/client.js:172:19)
    at emitOne (events.js:101:20)
    at Connection.emit (events.js:189:7)
    at Socket.<anonymous> (/app/node_modules/pg/lib/connection.js:121:12)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:189:7)
    at readableAddChunk (_stream_readable.js:176:18)
```
